### PR TITLE
docs: add skillx quick-start block to all 9 README variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ Created by [@titanwings](https://github.com/titanwings) · Powered by **Shanghai
 
 ---
 
+<!-- skillx:begin:setup-skillx -->
+## Try it with skillx
+
+[![Run with skillx](https://img.shields.io/badge/Run%20with-skillx-F97316)](https://skillx.run)
+
+Run this skill without installing anything:
+
+```bash
+skillx run --auto-approve https://github.com/titanwings/colleague-skill
+```
+
+Powered by [skillx](https://skillx.run) — fetch, scan, inject, and clean up any agent skill in one command.
+
+*Note: this command lets the agent act without per-step permission prompts. Only run if you trust the skill source. Drop `--auto-approve` if you'd rather approve each action manually.*
+<!-- skillx:end:setup-skillx -->
+
 ## 🆕 What's new in this major release?
 
 ### 1️⃣ From colleague-skill to dot-skill

--- a/docs/lang/README_DE.md
+++ b/docs/lang/README_DE.md
@@ -75,6 +75,22 @@ Created by [@titanwings](https://github.com/titanwings) · Powered by **Shanghai
 
 ---
 
+<!-- skillx:begin:setup-skillx -->
+## Mit skillx ausprobieren
+
+[![Run with skillx](https://img.shields.io/badge/Run%20with-skillx-F97316)](https://skillx.run)
+
+Führe diese Skill ohne Installation aus:
+
+```bash
+skillx run --auto-approve https://github.com/titanwings/colleague-skill
+```
+
+Powered by [skillx](https://skillx.run) — jede Agent-Skill mit einem Befehl abrufen, scannen, injizieren und aufräumen.
+
+*Hinweis: Dieser Befehl erlaubt dem Agenten, ohne schrittweise Berechtigungsabfragen zu handeln. Nur ausführen, wenn du der Skill-Quelle vertraust. Entferne `--auto-approve`, wenn du jede Aktion manuell bestätigen möchtest.*
+<!-- skillx:end:setup-skillx -->
+
 ## 🆕 Was ist neu in diesem Major-Release?
 
 ### 1️⃣ Von colleague-skill zu dot-skill

--- a/docs/lang/README_EN.md
+++ b/docs/lang/README_EN.md
@@ -75,6 +75,22 @@ Created by [@titanwings](https://github.com/titanwings) · Powered by **Shanghai
 
 ---
 
+<!-- skillx:begin:setup-skillx -->
+## Try it with skillx
+
+[![Run with skillx](https://img.shields.io/badge/Run%20with-skillx-F97316)](https://skillx.run)
+
+Run this skill without installing anything:
+
+```bash
+skillx run --auto-approve https://github.com/titanwings/colleague-skill
+```
+
+Powered by [skillx](https://skillx.run) — fetch, scan, inject, and clean up any agent skill in one command.
+
+*Note: this command lets the agent act without per-step permission prompts. Only run if you trust the skill source. Drop `--auto-approve` if you'd rather approve each action manually.*
+<!-- skillx:end:setup-skillx -->
+
 ## 🆕 What's new in this major release?
 
 ### 1️⃣ From colleague-skill to dot-skill

--- a/docs/lang/README_ES.md
+++ b/docs/lang/README_ES.md
@@ -75,6 +75,22 @@ Creado por [@titanwings](https://github.com/titanwings) · Impulsado por **Shang
 
 ---
 
+<!-- skillx:begin:setup-skillx -->
+## Pruébalo con skillx
+
+[![Run with skillx](https://img.shields.io/badge/Run%20with-skillx-F97316)](https://skillx.run)
+
+Ejecuta esta skill sin instalar nada:
+
+```bash
+skillx run --auto-approve https://github.com/titanwings/colleague-skill
+```
+
+Impulsado por [skillx](https://skillx.run) — obtén, escanea, inyecta y limpia cualquier agent skill con un comando.
+
+*Nota: este comando permite al agente actuar sin confirmaciones paso a paso. Ejecútalo solo si confías en la fuente. Quita `--auto-approve` si prefieres aprobar cada acción manualmente.*
+<!-- skillx:end:setup-skillx -->
+
 ## 🆕 Qué hay de nuevo en esta versión mayor
 
 ### 1️⃣ De colleague-skill a dot-skill

--- a/docs/lang/README_JA.md
+++ b/docs/lang/README_JA.md
@@ -75,6 +75,22 @@ Created by [@titanwings](https://github.com/titanwings) · Powered by **Shanghai
 
 ---
 
+<!-- skillx:begin:setup-skillx -->
+## skillx で試す
+
+[![Run with skillx](https://img.shields.io/badge/Run%20with-skillx-F97316)](https://skillx.run)
+
+このスキルをインストールなしで実行:
+
+```bash
+skillx run --auto-approve https://github.com/titanwings/colleague-skill
+```
+
+[skillx](https://skillx.run) によって提供 —— 任意の agent skill をワンコマンドで取得・スキャン・注入・クリーンアップ。
+
+*注意: このコマンドは agent が各ステップの許可確認なしで実行することを許可します。skill の提供元を信頼できる場合のみ実行してください。各アクションを手動で承認したい場合は `--auto-approve` を外してください。*
+<!-- skillx:end:setup-skillx -->
+
 ## 🆕 このメジャーリリースの新機能
 
 ### 1️⃣ colleague-skill から dot-skill へ

--- a/docs/lang/README_KO.md
+++ b/docs/lang/README_KO.md
@@ -75,6 +75,22 @@ Created by [@titanwings](https://github.com/titanwings) · Powered by **Shanghai
 
 ---
 
+<!-- skillx:begin:setup-skillx -->
+## skillx로 시도해 보기
+
+[![Run with skillx](https://img.shields.io/badge/Run%20with-skillx-F97316)](https://skillx.run)
+
+설치 없이 이 skill 실행:
+
+```bash
+skillx run --auto-approve https://github.com/titanwings/colleague-skill
+```
+
+[skillx](https://skillx.run) 제공 — 한 명령으로 agent skill을 가져오고, 스캔하고, 주입하고, 정리합니다.
+
+*참고: 이 명령은 agent가 단계별 권한 확인 없이 작동하도록 허용합니다. skill 출처를 신뢰하는 경우에만 실행하세요. 각 작업을 수동으로 승인하려면 `--auto-approve`를 제거하세요.*
+<!-- skillx:end:setup-skillx -->
+
 ## 🆕 이번 메이저 릴리스의 새로운 점
 
 ### 1️⃣ colleague-skill에서 dot-skill로

--- a/docs/lang/README_PT.md
+++ b/docs/lang/README_PT.md
@@ -75,6 +75,22 @@ Criado por [@titanwings](https://github.com/titanwings) · Powered by **Shanghai
 
 ---
 
+<!-- skillx:begin:setup-skillx -->
+## Experimente com skillx
+
+[![Run with skillx](https://img.shields.io/badge/Run%20with-skillx-F97316)](https://skillx.run)
+
+Execute esta skill sem instalar nada:
+
+```bash
+skillx run --auto-approve https://github.com/titanwings/colleague-skill
+```
+
+Desenvolvido com [skillx](https://skillx.run) — obtenha, escaneie, injete e limpe qualquer agent skill em um comando.
+
+*Nota: este comando permite que o agente aja sem confirmações passo a passo. Execute apenas se confiar na fonte da skill. Remova `--auto-approve` se preferir aprovar cada ação manualmente.*
+<!-- skillx:end:setup-skillx -->
+
 ## 🆕 O que há de novo nesta grande versão?
 
 ### 1️⃣ De colleague-skill para dot-skill

--- a/docs/lang/README_RU.md
+++ b/docs/lang/README_RU.md
@@ -75,6 +75,22 @@
 
 ---
 
+<!-- skillx:begin:setup-skillx -->
+## Попробуйте со skillx
+
+[![Run with skillx](https://img.shields.io/badge/Run%20with-skillx-F97316)](https://skillx.run)
+
+Запустите эту skill без установки:
+
+```bash
+skillx run --auto-approve https://github.com/titanwings/colleague-skill
+```
+
+На базе [skillx](https://skillx.run) — одна команда, чтобы получить, просканировать, внедрить и удалить любую agent skill.
+
+*Примечание: эта команда позволяет агенту действовать без пошаговых запросов разрешения. Запускайте только если доверяете источнику skill. Удалите `--auto-approve`, если хотите подтверждать каждое действие вручную.*
+<!-- skillx:end:setup-skillx -->
+
 ## 🆕 Что нового в этом крупном релизе?
 
 ### 1️⃣ От colleague-skill к dot-skill

--- a/docs/lang/README_ZH.md
+++ b/docs/lang/README_ZH.md
@@ -75,6 +75,22 @@ Created by [@titanwings](https://github.com/titanwings) · Powered by **Shanghai
 
 ---
 
+<!-- skillx:begin:setup-skillx -->
+## 用 skillx 试试
+
+[![Run with skillx](https://img.shields.io/badge/Run%20with-skillx-F97316)](https://skillx.run)
+
+无需安装，直接运行这个 skill：
+
+```bash
+skillx run --auto-approve https://github.com/titanwings/colleague-skill
+```
+
+由 [skillx](https://skillx.run) 提供支持 —— 一条命令拉取、扫描、注入并清理任意 agent skill。
+
+*注意：此命令允许 agent 在执行过程中跳过逐步权限确认。仅在你信任 skill 来源时使用。若希望手动确认每一步操作，请去掉 `--auto-approve`。*
+<!-- skillx:end:setup-skillx -->
+
 ## 🆕 这次大版本更新了什么？
 
 ### 1️⃣ 从 colleague-skill 升级为 dot-skill


### PR DESCRIPTION
## Summary
- 在 9 个语言版本 README（主 README + `docs/lang/README_{DE,EN,ES,JA,KO,PT,RU,ZH}.md`）中统一添加 skillx 快速启动区块
- 提供 `skillx run --auto-approve https://github.com/titanwings/colleague-skill` 一行命令，让用户无需安装即可试用本 skill
- 使用 `<!-- skillx:begin:setup-skillx --> ... <!-- skillx:end:setup-skillx -->` 注释包裹，便于后续自动化维护
- 附带安全提示：说明 `--auto-approve` 的作用，并建议不信任来源时去掉该参数

## Test plan
- [x] 目视检查 9 份 README 区块位置与排版一致
- [x] 确认代码块中仓库地址指向 `titanwings/colleague-skill`
- [x] 确认 begin/end 注释标签配对，方便自动化工具识别
