### PR TITLE
fix: keep work-only skills from referring to Persona

### DIFF
--- a/tests/test_skill_writer.py
+++ b/tests/test_skill_writer.py
@@ -147,6 +147,62 @@ class SkillWriterTest(unittest.TestCase):
             self.assertIn("仅 Work，无 Persona", work_skill)
             self.assertIn("仅 Persona，无工作能力", persona_skill)
 
+    def test_work_only_skill_replaces_persona_handoff(self) -> None:
+        handoff = "如果被问到职责范围外的问题，以该同事的方式回应（参见 Persona 部分）。"
+        work_content = (
+            "## 工作能力使用说明\n\n"
+            "当用户要求你完成以下任务时，严格按照上述规范执行。\n\n"
+            f"{handoff}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base_dir = Path(tmp_dir) / "skills" / "colleague"
+            zh_meta = {
+                "name": "Eulalie",
+                "language": "zh-CN",
+                "profile": {
+                    "company": "ByteDance",
+                    "level": "L2-1",
+                    "role": "Backend Engineer",
+                },
+            }
+            en_meta = {
+                "name": "Eulalie",
+                "language": "en",
+                "profile": {
+                    "company": "ByteDance",
+                    "level": "L2-1",
+                    "role": "Backend Engineer",
+                },
+            }
+
+            zh_dir = skill_writer.create_skill(
+                base_dir / "zh",
+                "zhangsan",
+                zh_meta,
+                work_content,
+                "Persona body",
+            )
+            en_dir = skill_writer.create_skill(
+                base_dir / "en",
+                "zhangsan",
+                en_meta,
+                work_content,
+                "Persona body",
+            )
+
+            stored_work = (zh_dir / "work.md").read_text(encoding="utf-8")
+            combined = (zh_dir / "SKILL.md").read_text(encoding="utf-8")
+            zh_work_skill = (zh_dir / "work_skill.md").read_text(encoding="utf-8")
+            en_work_skill = (en_dir / "work_skill.md").read_text(encoding="utf-8")
+
+            self.assertIn(handoff, stored_work)
+            self.assertIn(handoff, combined)
+            self.assertNotIn(handoff, zh_work_skill)
+            self.assertNotIn(handoff, en_work_skill)
+            self.assertIn(skill_writer.WORK_ONLY_FALLBACK_ZH, zh_work_skill)
+            self.assertIn(skill_writer.WORK_ONLY_FALLBACK_EN, en_work_skill)
+            self.assertNotIn(skill_writer.WORK_ONLY_FALLBACK_ZH, combined)
+
     def test_create_celebrity_adds_research_dirs_and_toolchain(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             base_dir = Path(tmp_dir) / "skills" / "celebrity"

--- a/tests/test_skill_writer.py
+++ b/tests/test_skill_writer.py
@@ -148,11 +148,23 @@ class SkillWriterTest(unittest.TestCase):
             self.assertIn("仅 Persona，无工作能力", persona_skill)
 
     def test_work_only_skill_replaces_persona_handoff(self) -> None:
-        handoff = "如果被问到职责范围外的问题，以该同事的方式回应（参见 Persona 部分）。"
-        work_content = (
+        zh_handoff = "如果被问到职责范围外的问题，以该同事的方式回应（参见 Persona 部分）。"
+        en_handoff = (
+            "If you are asked a question outside your recorded responsibilities, "
+            "respond in this colleague's style (see the Persona section)."
+        )
+        zh_work_content = (
             "## 工作能力使用说明\n\n"
             "当用户要求你完成以下任务时，严格按照上述规范执行。\n\n"
-            f"{handoff}\n"
+            f"{zh_handoff}\n"
+        )
+        en_work_content = (
+            "## Scope rule\n\n"
+            "If asked outside your recorded responsibilities:\n"
+            "- State the evidence gap\n\n"
+            "## Persona naming note\n\n"
+            "Keep this documentation sentence.\n\n"
+            f"{en_handoff}\n"
         )
         with tempfile.TemporaryDirectory() as tmp_dir:
             base_dir = Path(tmp_dir) / "skills" / "colleague"
@@ -179,29 +191,41 @@ class SkillWriterTest(unittest.TestCase):
                 base_dir / "zh",
                 "zhangsan",
                 zh_meta,
-                work_content,
+                zh_work_content,
                 "Persona body",
             )
             en_dir = skill_writer.create_skill(
                 base_dir / "en",
                 "zhangsan",
                 en_meta,
-                work_content,
+                en_work_content,
                 "Persona body",
             )
 
-            stored_work = (zh_dir / "work.md").read_text(encoding="utf-8")
-            combined = (zh_dir / "SKILL.md").read_text(encoding="utf-8")
+            zh_stored_work = (zh_dir / "work.md").read_text(encoding="utf-8")
+            zh_combined = (zh_dir / "SKILL.md").read_text(encoding="utf-8")
+            en_stored_work = (en_dir / "work.md").read_text(encoding="utf-8")
+            en_combined = (en_dir / "SKILL.md").read_text(encoding="utf-8")
             zh_work_skill = (zh_dir / "work_skill.md").read_text(encoding="utf-8")
             en_work_skill = (en_dir / "work_skill.md").read_text(encoding="utf-8")
 
-            self.assertIn(handoff, stored_work)
-            self.assertIn(handoff, combined)
-            self.assertNotIn(handoff, zh_work_skill)
-            self.assertNotIn(handoff, en_work_skill)
+            self.assertIn(zh_handoff, zh_stored_work)
+            self.assertIn(zh_handoff, zh_combined)
+            self.assertIn(en_handoff, en_stored_work)
+            self.assertIn(en_handoff, en_combined)
+            self.assertNotIn(zh_handoff, zh_work_skill)
+            self.assertNotIn(en_handoff, en_work_skill)
+            self.assertIn("If asked outside your recorded responsibilities:", en_work_skill)
+            self.assertIn("## Persona naming note", en_work_skill)
+            self.assertIn("Keep this documentation sentence.", en_work_skill)
             self.assertIn(skill_writer.WORK_ONLY_FALLBACK_ZH, zh_work_skill)
             self.assertIn(skill_writer.WORK_ONLY_FALLBACK_EN, en_work_skill)
-            self.assertNotIn(skill_writer.WORK_ONLY_FALLBACK_ZH, combined)
+            self.assertIn("不要臆造缺失信息", zh_work_skill)
+            self.assertNotIn("不要推断", zh_work_skill)
+            self.assertIn("Do not fabricate missing information", en_work_skill)
+            self.assertNotIn("Do not infer", en_work_skill)
+            self.assertNotIn(skill_writer.WORK_ONLY_FALLBACK_ZH, zh_combined)
+            self.assertNotIn(skill_writer.WORK_ONLY_FALLBACK_EN, en_combined)
 
     def test_create_celebrity_adds_research_dirs_and_toolchain(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tools/skill_writer.py
+++ b/tools/skill_writer.py
@@ -164,18 +164,51 @@ def render_combined_skill(meta: dict, work_content: str, persona_content: str) -
     )
 
 
+_PERSONA_HANDOFF_PATTERNS = (
+    re.compile(r"如果被问到职责范围外的问题，以该同事的方式回应（参见 Persona 部分）。\s*"),
+    re.compile(
+        r"If (?:you are )?asked (?:a question )?outside (?:your|the) "
+        r"(?:recorded )?responsibilities[^.]*Persona[^.]*\.\s*",
+        re.IGNORECASE,
+    ),
+)
+
+WORK_ONLY_FALLBACK_ZH = (
+    "如果问题超出已记录的职责范围，或原材料不足以回答，请直接说明缺口。"
+    "不要推断，也不要引用 Persona。"
+)
+WORK_ONLY_FALLBACK_EN = (
+    "If the question is outside the recorded responsibilities or the source "
+    "material is insufficient, state the gap. Do not infer or refer to Persona."
+)
+
+
+def work_only_content(work_content: str, *, chinese: bool) -> str:
+    """Copy Work text for the Work-only skill, without a Persona handoff."""
+    text = work_content
+    for pattern in _PERSONA_HANDOFF_PATTERNS:
+        text = pattern.sub("", text)
+    text = text.rstrip()
+    fallback = WORK_ONLY_FALLBACK_ZH if chinese else WORK_ONLY_FALLBACK_EN
+    if fallback not in text:
+        text = f"{text}\n\n{fallback}" if text else fallback
+    return text
+
+
 def render_work_skill(meta: dict, work_content: str) -> str:
     """Render the work-only skill artifact."""
     artifacts = meta["artifacts"]
+    chinese = prefers_chinese(meta)
     description = (
         f"{meta['display_name']} 的工作能力（仅 Work，无 Persona）"
-        if prefers_chinese(meta)
+        if chinese
         else f"{meta['display_name']} work capability only (without persona)"
     )
+    body = work_only_content(work_content, chinese=chinese)
     return (
         f"---\nname: {artifacts['work_name']}\n"
         f"description: {description}\n"
-        f"user-invocable: true\n---\n\n{work_content}\n"
+        f"user-invocable: true\n---\n\n{body}\n"
     )
 
 

--- a/tools/skill_writer.py
+++ b/tools/skill_writer.py
@@ -168,18 +168,19 @@ _PERSONA_HANDOFF_PATTERNS = (
     re.compile(r"如果被问到职责范围外的问题，以该同事的方式回应（参见 Persona 部分）。\s*"),
     re.compile(
         r"If (?:you are )?asked (?:a question )?outside (?:your|the) "
-        r"(?:recorded )?responsibilities[^.]*Persona[^.]*\.\s*",
+        r"(?:recorded )?responsibilities[^.\n]*Persona[^.\n]*\.\s*",
         re.IGNORECASE,
     ),
 )
 
 WORK_ONLY_FALLBACK_ZH = (
     "如果问题超出已记录的职责范围，或原材料不足以回答，请直接说明缺口。"
-    "不要推断，也不要引用 Persona。"
+    "不要臆造缺失信息，也不要引用 Persona。"
 )
 WORK_ONLY_FALLBACK_EN = (
     "If the question is outside the recorded responsibilities or the source "
-    "material is insufficient, state the gap. Do not infer or refer to Persona."
+    "material is insufficient, state the gap. Do not fabricate missing information "
+    "or refer to Persona."
 )
 
 


### PR DESCRIPTION
## Summary / 摘要

Work-only skills are labeled "without persona" but still told the model to answer out-of-scope questions via the Persona section. Combined skills keep that handoff; Work-only now strips it and adds a self-contained fallback.

Work-only 入口写着「仅 Work，无 Persona」，却仍要求职责外问题参见 Persona。完整模式保留原交接句；Work-only 去掉该句并补上自包含的范围外规则。

## Changes / 变更

- `render_work_skill()` removes the canonical Persona handoff from a copy of `work_content` and appends a Work-only fallback
- Stored `work.md` and `render_combined_skill()` are unchanged
- Regression coverage in `tests/test_skill_writer.py` for both artifacts

## Motivation / 动机

Closes #134

## Testing / 测试

- [x] `python -m unittest discover -s tests -p test_skill_writer.py` passed
- [x] `python -m compileall tools/` passed
- [x] Manually tested: N/A (generator-only; verified via unit test with the template handoff sentence)

## Checklist / 检查清单

- [x] I read CONTRIBUTING.md
- [x] Docs updated if behavior or usage changed (README / SKILL.md / INSTALL.md)
- [x] No secrets, tokens, or personal data committed
- [x] New dependencies added to `requirements.txt` (if any)
- [x] Tests added/updated for new functionality (or reason explained above)
