### PR TITLE
feat: local evidence intake (EML/MBOX parser, panel command, directory harvest)

### DIFF
--- a/packages/adapters/src/builtin-parsers.test.ts
+++ b/packages/adapters/src/builtin-parsers.test.ts
@@ -156,7 +156,7 @@ describe("builtin local material parsers", () => {
     });
   });
 
-  it("exposes only the five Preview media types through a fresh registry", () => {
+  it("exposes only the reviewed Preview media types through a fresh registry", () => {
     const first = createBuiltinParserRegistry();
     const second = createBuiltinParserRegistry();
 
@@ -168,7 +168,9 @@ describe("builtin local material parsers", () => {
         .sort(),
     ).toEqual([
       "application/json",
+      "application/mbox",
       "application/x-subrip",
+      "message/rfc822",
       "text/markdown",
       "text/plain",
       "text/vtt",

--- a/packages/adapters/src/builtin-parsers.ts
+++ b/packages/adapters/src/builtin-parsers.ts
@@ -1,5 +1,7 @@
 import { DistillyError } from "@distilly/protocol";
 
+import { parseEmailMessages } from "./email-parser.js";
+
 import type {
   MaterialParser,
   ParsedMaterial,
@@ -88,6 +90,39 @@ const documentParser = (
         { method: "document_text", producer: id },
         context.maximumOutputBytes,
       );
+    });
+  },
+});
+
+const emailParser = (id: string, mediaType: string, mbox: boolean): MaterialParser => ({
+  id,
+  accepts: Object.freeze([mediaType]),
+  parse(input, context) {
+    return Promise.resolve().then(() => {
+      if (input.mediaType !== mediaType) {
+        throw invalidInput(`Parser ${id} does not accept ${input.mediaType}.`, "mediaType");
+      }
+      // Parse the bytes directly: decoding the container first would double-decode
+      // any 8-bit part whose declared charset is not UTF-8.
+      const parsed = parseEmailMessages(input.bytes, mbox);
+      const rendered = parsed.messages.map((message) => message.body).join("\n\n---\n\n");
+      const warnings: string[] = [];
+      if (parsed.skippedAttachments > 0) {
+        warnings.push(
+          `${parsed.skippedAttachments} non-text part(s) were not included as evidence.`,
+        );
+      }
+      if (parsed.undecodableParts > 0) {
+        warnings.push(`${parsed.undecodableParts} part(s) could not be decoded as text.`);
+      }
+      const result = draft(
+        input,
+        rendered,
+        "document",
+        { method: "document_text", producer: id },
+        context.maximumOutputBytes,
+      );
+      return { ...result, warnings };
     });
   },
 });
@@ -183,6 +218,8 @@ const subtitleParser = (id: string, mediaType: string): MaterialParser => ({
 export const createBuiltinParserRegistry = (): ParserRegistry => {
   const registry = new ParserRegistry();
   for (const parser of [
+    emailParser("distilly-eml", "message/rfc822", false),
+    emailParser("distilly-mbox", "application/mbox", true),
     documentParser("distilly-json", "application/json", parseJson),
     subtitleParser("distilly-srt", "application/x-subrip"),
     documentParser("distilly-markdown", "text/markdown", (text) => text),

--- a/packages/adapters/src/email-parser.test.ts
+++ b/packages/adapters/src/email-parser.test.ts
@@ -1,0 +1,609 @@
+import { describe, expect, it } from "vitest";
+
+import { parseEmailMessages } from "./email-parser.js";
+
+const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+const SIMPLE = [
+  "From: Ada Lovelace <ada@example.com>",
+  "To: Charles Babbage <charles@example.com>",
+  "Date: Mon, 01 Sep 2026 10:00:00 +0000",
+  "Subject: Notes on the engine",
+  "",
+  "The engine needs a sharper distinction between data and process.",
+  "",
+  "— Ada",
+  "",
+].join("\r\n");
+
+const MULTIPART = [
+  "From: Ada <ada@example.com>",
+  "To: Charles <charles@example.com>",
+  "Subject: Design review",
+  "MIME-Version: 1.0",
+  'Content-Type: multipart/mixed; boundary="outer"',
+  "",
+  "--outer",
+  'Content-Type: multipart/alternative; boundary="inner"',
+  "",
+  "--inner",
+  "Content-Type: text/plain; charset=utf-8",
+  "",
+  "Plain view of the design.",
+  "--inner",
+  "Content-Type: text/html; charset=utf-8",
+  "",
+  "<html><body><p>HTML view of the <b>design</b>.</p></body></html>",
+  "--inner--",
+  "--outer",
+  "Content-Type: application/pdf; name=spec.pdf",
+  "Content-Disposition: attachment; filename=spec.pdf",
+  "Content-Transfer-Encoding: base64",
+  "",
+  "JVBERi0xLjQK",
+  "--outer--",
+  "",
+].join("\n");
+
+const BASE64_QUOTED = [
+  "From: =?UTF-8?B?5byg5LiJ?= <zhang@example.com>",
+  "To: team@example.com",
+  "Subject: =?UTF-8?B?5rWL6K+V5Li76aKY?=",
+  "MIME-Version: 1.0",
+  'Content-Type: text/plain; charset="utf-8"',
+  "Content-Transfer-Encoding: base64",
+  "",
+  Buffer.from("第一行\n第二行\n", "utf8").toString("base64"),
+  "",
+].join("\r\n");
+
+const QUOTED_PRINTABLE = [
+  "From: Ada <ada@example.com>",
+  "Subject: QP test",
+  "Content-Type: text/plain; charset=iso-8859-1",
+  "Content-Transfer-Encoding: quoted-printable",
+  "",
+  "Caf=C3=A9 at 10:00 =E2=80=94 bring the notes.",
+  "",
+].join("\r\n");
+
+const MBOX = [
+  "From ada@example.com Mon Sep 01 10:00:00 2026",
+  "From: Ada <ada@example.com>",
+  "Subject: first",
+  "",
+  "First message body.",
+  "",
+  "From charles@example.com Mon Sep 01 11:00:00 2026",
+  "From: Charles <charles@example.com>",
+  "Subject: second",
+  "",
+  "Second message body.",
+  "",
+].join("\n");
+
+/**
+ * Builds a single-part message from raw body bytes and explicit header lines.
+ *
+ * @param headerLines - Header lines without the terminating blank line.
+ * @param body - Raw body bytes.
+ * @returns Complete message bytes.
+ */
+const rawMessage = (headerLines: readonly string[], body: Uint8Array): Uint8Array => {
+  const head = bytes(`${headerLines.join("\r\n")}\r\n\r\n`);
+  const combined = new Uint8Array(head.length + body.length);
+  combined.set(head, 0);
+  combined.set(body, head.length);
+  return combined;
+};
+
+describe("mail material parsing", () => {
+  it("renders a simple message with decoded headers and body", () => {
+    const parsed = parseEmailMessages(bytes(SIMPLE), false);
+    expect(parsed.messages).toHaveLength(1);
+    expect(parsed.messages[0]).toEqual({
+      from: "Ada Lovelace <ada@example.com>",
+      to: "Charles Babbage <charles@example.com>",
+      date: "Mon, 01 Sep 2026 10:00:00 +0000",
+      subject: "Notes on the engine",
+      body: "From: Ada Lovelace <ada@example.com>\nTo: Charles Babbage <charles@example.com>\nDate: Mon, 01 Sep 2026 10:00:00 +0000\nSubject: Notes on the engine\n\nThe engine needs a sharper distinction between data and process.\n\n— Ada",
+    });
+    expect(parsed.skippedAttachments).toBe(0);
+    expect(parsed.undecodableParts).toBe(0);
+  });
+
+  it("prefers the plain alternative of a nested multipart and counts the attachment", () => {
+    const parsed = parseEmailMessages(bytes(MULTIPART), false);
+    expect(parsed.messages).toHaveLength(1);
+    expect(parsed.messages[0]?.body).toContain("Plain view of the design.");
+    expect(parsed.messages[0]?.body).not.toContain("HTML view");
+    expect(parsed.skippedAttachments).toBe(1);
+    expect(parsed.undecodableParts).toBe(0);
+  });
+
+  it("falls back to the HTML part when no plain part exists and strips markup", () => {
+    const htmlOnly = [
+      "From: Ada <ada@example.com>",
+      "Content-Type: text/html; charset=utf-8",
+      "",
+      "<html><body><p>Only <b>markup</b> here</p></body></html>",
+      "",
+    ].join("\r\n");
+    const parsed = parseEmailMessages(bytes(htmlOnly), false);
+    expect(parsed.messages[0]?.body).toContain("Only markup here");
+    expect(parsed.messages[0]?.body).not.toContain("<b>");
+  });
+
+  it("decodes RFC 2047 header words and a base64 UTF-8 body", () => {
+    const parsed = parseEmailMessages(bytes(BASE64_QUOTED), false);
+    expect(parsed.messages[0]?.from).toBe("张三 <zhang@example.com>");
+    expect(parsed.messages[0]?.subject).toBe("测试主题");
+    expect(parsed.messages[0]?.body).toContain("第一行\n第二行");
+  });
+
+  it("decodes a quoted-printable body through its declared charset", () => {
+    const parsed = parseEmailMessages(bytes(QUOTED_PRINTABLE), false);
+    expect(parsed.messages[0]?.body).toContain("Café at 10:00 — bring the notes.");
+  });
+
+  it("splits an mbox mailbox into one message per separator", () => {
+    const parsed = parseEmailMessages(bytes(MBOX), true);
+    expect(parsed.messages).toHaveLength(2);
+    expect(parsed.messages[0]?.subject).toBe("first");
+    expect(parsed.messages[0]?.body).toContain("First message body.");
+    expect(parsed.messages[1]?.subject).toBe("second");
+    expect(parsed.messages[1]?.body).toContain("Second message body.");
+  });
+
+  it("rejects a source with no message, a header-only source, and an unreadable body", () => {
+    expect(() => parseEmailMessages(bytes("not a message at all"), false)).toThrow(
+      /did not contain a decodable message/u,
+    );
+    expect(() => parseEmailMessages(bytes("Subject: only headers\r\n\r\n"), false)).toThrow(
+      /did not contain a decodable message/u,
+    );
+    expect(() => parseEmailMessages(bytes(""), true)).toThrow(
+      /did not contain a decodable message/u,
+    );
+    expect(() =>
+      parseEmailMessages(
+        bytes(
+          "From: a@example.com\r\nContent-Transfer-Encoding: x-uuencode\r\n\r\nbegin 644 x\r\n",
+        ),
+        false,
+      ),
+    ).toThrow(/did not contain a decodable message/u);
+  });
+
+  // Regression coverage for the independent audit of the first implementation.
+  describe("audit regressions", () => {
+    it("decodes an 8-bit body through the charset its part declares", () => {
+      const message = rawMessage(
+        [
+          "From: gb@example.com",
+          "Subject: GB18030 raw",
+          "Content-Type: text/plain; charset=GB18030",
+          "Content-Transfer-Encoding: 8bit",
+        ],
+        Uint8Array.from([0xd6, 0xd0, 0xce, 0xc4]),
+      );
+      const body = parseEmailMessages(message, false).messages[0]?.body ?? "";
+      expect(body).toContain("中文");
+      expect(body).not.toContain("脰");
+    });
+
+    it("honours a declared charset outside the built-in candidate list", () => {
+      const message = rawMessage(
+        [
+          "From: jp@example.com",
+          "Subject: shift_jis raw",
+          "Content-Type: text/plain; charset=shift_jis",
+          "Content-Transfer-Encoding: 8bit",
+        ],
+        Uint8Array.from([0x93, 0xfa, 0x96, 0x7b]),
+      );
+      expect(parseEmailMessages(message, false).messages[0]?.body).toContain("日本");
+    });
+
+    it("never turns an untyped binary part into evidence", () => {
+      const message = [
+        "From: a@example.com",
+        "MIME-Version: 1.0",
+        'Content-Type: multipart/mixed; boundary="b"',
+        "",
+        "--b",
+        "",
+        "\u0000\u0001\u0002\u0003binary-ish",
+        "--b",
+        "Content-Type: text/plain; charset=utf-8",
+        "",
+        "Real text body.",
+        "--b--",
+        "",
+      ].join("\r\n");
+      const parsed = parseEmailMessages(bytes(message), false);
+      expect(parsed.messages[0]?.body).toContain("Real text body.");
+      expect(parsed.messages[0]?.body).not.toContain("\u0000");
+      expect(parsed.skippedAttachments).toBe(1);
+    });
+
+    it("refuses a top-level binary payload instead of emitting it as text", () => {
+      const message = rawMessage(
+        [
+          "From: a@example.com",
+          "Content-Type: application/octet-stream",
+          "Content-Transfer-Encoding: base64",
+        ],
+        bytes("AAECAw=="),
+      );
+      expect(() => parseEmailMessages(message, false)).toThrow(
+        /did not contain a decodable message/u,
+      );
+    });
+
+    it("survives prose containing angle brackets and decodes numeric entities", () => {
+      const html = [
+        "From: a@example.com",
+        "Content-Type: text/html; charset=utf-8",
+        "",
+        "<p>caf&#233; &#x1F600; and 2 < 3 and a<b</p>",
+        "",
+      ].join("\r\n");
+      const body = parseEmailMessages(bytes(html), false).messages[0]?.body ?? "";
+      expect(body).toContain("café 😀");
+      expect(body).toContain("2 < 3");
+    });
+
+    it("accepts a boundary delimiter carrying transport padding", () => {
+      const message = [
+        "From: a@example.com",
+        'Content-Type: multipart/mixed; boundary="PAD"',
+        "",
+        "--PAD ",
+        "Content-Type: text/plain; charset=utf-8",
+        "",
+        "Padded delimiter body.",
+        "--PAD-- ",
+        "",
+      ].join("\r\n");
+      expect(parseEmailMessages(bytes(message), false).messages[0]?.body).toContain(
+        "Padded delimiter body.",
+      );
+    });
+
+    it("uses the HTML alternative when the plain alternative is empty", () => {
+      const message = [
+        "From: a@example.com",
+        'Content-Type: multipart/alternative; boundary="b"',
+        "",
+        "--b",
+        "Content-Type: text/plain; charset=utf-8",
+        "",
+        "   ",
+        "--b",
+        "Content-Type: text/html; charset=utf-8",
+        "",
+        "<p>HTML fallback text.</p>",
+        "--b--",
+        "",
+      ].join("\r\n");
+      expect(parseEmailMessages(bytes(message), false).messages[0]?.body).toContain(
+        "HTML fallback text.",
+      );
+    });
+
+    it("joins adjacent encoded header words without inserting a space", () => {
+      const fold = [
+        "From: a@example.com",
+        "Subject: =?utf-8?B?UmVz?=",
+        " =?utf-8?B?dW3DqQ==?=",
+        "",
+        "Body text.",
+        "",
+      ].join("\r\n");
+      // "UmVz" decodes to "Res" and "dW3DqQ==" to "umé"; adjacent words concatenate
+      // directly, so the correct value is "Resumé" and not "Résumé".
+      expect(parseEmailMessages(bytes(fold), false).messages[0]?.subject).toBe("Resumé");
+    });
+
+    it("rejects a body with no visible character", () => {
+      const zwsp = rawMessage(
+        ["From: a@example.com", "Subject: z", "Content-Type: text/plain; charset=utf-8"],
+        bytes("\u200b"),
+      );
+      expect(() => parseEmailMessages(zwsp, false)).toThrow(/did not contain a decodable message/u);
+    });
+
+    it("reports the nesting limit instead of a generic failure", () => {
+      const depth = 30;
+      const lines: string[] = ["From: a@example.com"];
+      for (let level = 0; level < depth; level += 1) {
+        lines.push(`Content-Type: multipart/mixed; boundary="b${level}"`, "", `--b${level}`);
+      }
+      lines.push("Content-Type: text/plain", "", "DEEP-TEXT", `--b${depth - 1}--`, "");
+      expect(() => parseEmailMessages(bytes(lines.join("\r\n")), false)).toThrow(
+        /nests more than 16 multipart levels/u,
+      );
+    });
+
+    it("does not truncate a message at an unescaped From line inside its body", () => {
+      const mailbox = [
+        "From ada@example.com Mon Sep 01 10:00:00 2026",
+        "From: Ada <ada@example.com>",
+        "Subject: plan",
+        "",
+        "Before the separator.",
+        "From now on the plan changes.",
+        "After the separator.",
+        "",
+      ].join("\n");
+      const parsed = parseEmailMessages(bytes(mailbox), true);
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0]?.body).toContain("From now on the plan changes.");
+      expect(parsed.messages[0]?.body).toContain("After the separator.");
+    });
+
+    it("keeps the message of a mailbox whose separator carries no month name", () => {
+      const mailbox = [
+        "From ada@example.com 2026-09-01 10:00:00",
+        "From: Ada <ada@example.com>",
+        "Subject: dash date",
+        "",
+        "Body with a dash date separator.",
+        "",
+      ].join("\n");
+      const parsed = parseEmailMessages(bytes(mailbox), true);
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0]?.body).toContain("dash date separator");
+    });
+  });
+
+  // Regression coverage for the second independent audit, which found that the first
+  // round of fixes had introduced new defects.
+  describe("re-audit regressions", () => {
+    const MAILBOX_FORMATS: readonly (readonly [string, string])[] = [
+      ["ctime padded day", "From a@example.com Fri Sep  1 10:00:00 2026"],
+      ["ctime two-digit day", "From a@example.com Fri Sep 11 10:00:00 2026"],
+      ["thunderbird dash", "From - Fri Sep 11 10:00:00 2026"],
+      ["rfc 2822", "From a@example.com Fri, 11 Sep 2026 10:00:00 +0000"],
+      ["iso 8601", "From a@example.com 2026-09-11T10:00:00Z"],
+      ["epoch seconds", "From a@example.com 1789060600"],
+      ["no date", "From a@example.com"],
+    ];
+
+    it.each(MAILBOX_FORMATS)("splits a mailbox whose separators use %s", (_label, first) => {
+      const mailbox = [
+        first,
+        "From: A <a@example.com>",
+        "Subject: one",
+        "",
+        "First body.",
+        "",
+        first.replace(/^From \S+/u, "From b@example.com"),
+        "From: B <b@example.com>",
+        "Subject: two",
+        "",
+        "Second body.",
+        "",
+      ].join("\n");
+      const parsed = parseEmailMessages(bytes(mailbox), true);
+      expect(parsed.messages).toHaveLength(2);
+      expect(parsed.messages[0]?.subject).toBe("one");
+      expect(parsed.messages[1]?.subject).toBe("two");
+      expect(parsed.messages[0]?.body).not.toContain("Subject: two");
+    });
+
+    it("treats a header-only empty part as empty rather than as body text", () => {
+      const message = [
+        "From: e@example.com",
+        "Subject: empty alt",
+        'Content-Type: multipart/alternative; boundary="b"',
+        "",
+        "--b",
+        "Content-Type: text/plain; charset=utf-8",
+        "",
+        "--b",
+        "Content-Type: text/html; charset=utf-8",
+        "",
+        "<p>Readable HTML alternative.</p>",
+        "--b--",
+        "",
+      ].join("\r\n");
+      const body = parseEmailMessages(bytes(message), false).messages[0]?.body ?? "";
+      expect(body).toContain("Readable HTML alternative.");
+      expect(body).not.toContain("Content-Type: text/plain");
+    });
+
+    it("decodes an unencoded 8-bit UTF-8 header value", () => {
+      const message = bytes(
+        ["From: José García <jose@example.com>", "Subject: Raw é€", "", "body", ""].join("\r\n"),
+      );
+      const parsed = parseEmailMessages(message, false);
+      expect(parsed.messages[0]?.from).toBe("José García <jose@example.com>");
+      expect(parsed.messages[0]?.subject).toBe("Raw é€");
+    });
+
+    it("never treats a declared text/plain payload with control bytes as evidence", () => {
+      const message = [
+        "From: c@example.com",
+        'Content-Type: multipart/mixed; boundary="b"',
+        "",
+        "--b",
+        "Content-Type: text/plain; charset=utf-8",
+        "",
+        "\u0000\u0001\u0002\u0003ÿþ",
+        "--b",
+        "Content-Type: text/plain; charset=utf-8",
+        "",
+        "REAL-TEXT",
+        "--b--",
+        "",
+      ].join("\r\n");
+      const parsed = parseEmailMessages(bytes(message), false);
+      expect(parsed.messages[0]?.body).toContain("REAL-TEXT");
+      expect(parsed.messages[0]?.body).not.toContain("\u0000");
+      expect(parsed.skippedAttachments).toBe(1);
+    });
+
+    it("stays fast on HTML with many unclosed script openers", () => {
+      const message = [
+        "From: h@example.com",
+        "Content-Type: text/html; charset=utf-8",
+        "",
+        `${"<script>".repeat(20_000)}visible text`,
+        "",
+      ].join("\r\n");
+      const started = Date.now();
+      const parsed = parseEmailMessages(bytes(message), false);
+      expect(parsed.messages[0]?.body).toContain("visible text");
+      expect(Date.now() - started).toBeLessThan(2_000);
+    });
+
+    it("does not double-decode an escaped numeric entity", () => {
+      const html = [
+        "From: h@example.com",
+        "Content-Type: text/html; charset=utf-8",
+        "",
+        "<p>literal &amp;#233; stays literal</p>",
+        "",
+      ].join("\r\n");
+      const body = parseEmailMessages(bytes(html), false).messages[0]?.body ?? "";
+      expect(body).toContain("&#233;");
+      expect(body).not.toContain("é");
+    });
+
+    it("enforces the nesting limit at the documented depth", () => {
+      const depth = 17;
+      const lines: string[] = ["From: a@example.com"];
+      for (let level = 0; level < depth; level += 1) {
+        lines.push(`Content-Type: multipart/mixed; boundary="b${level}"`, "", `--b${level}`);
+      }
+      lines.push("Content-Type: text/plain", "", "DEEP-TEXT", `--b${depth - 1}--`, "");
+      expect(() => parseEmailMessages(bytes(lines.join("\r\n")), false)).toThrow(
+        /nests more than 16 multipart levels/u,
+      );
+    });
+
+    it("honours a specific legacy declaration over a coincidental UTF-8 reading", () => {
+      // Shift_JIS C3 A9 C3 A9 C3 A9 is half-width katakana, not "ééé".
+      const message = rawMessage(
+        [
+          "From: jp@example.com",
+          "Content-Type: text/plain; charset=shift_jis",
+          "Content-Transfer-Encoding: 8bit",
+        ],
+        Uint8Array.from([0xc3, 0xa9, 0xc3, 0xa9, 0xc3, 0xa9]),
+      );
+      expect(parseEmailMessages(message, false).messages[0]?.body).toContain("ﾃｩﾃｩﾃｩ");
+    });
+
+    it("still prefers UTF-8 when the declaration is a label senders misuse", () => {
+      const message = rawMessage(
+        [
+          "From: m@example.com",
+          "Content-Type: text/plain; charset=iso-8859-1",
+          "Content-Transfer-Encoding: 8bit",
+        ],
+        bytes("café — done"),
+      );
+      expect(parseEmailMessages(message, false).messages[0]?.body).toContain("café — done");
+    });
+
+    it("does not split on an address quoted at the start of a body line", () => {
+      const mailbox = [
+        "From a@example.com Fri Sep 11 10:00:00 2026",
+        "From: A <a@example.com>",
+        "Subject: one",
+        "",
+        "Before.",
+        "From alice@example.com wrote:",
+        "After.",
+        "",
+      ].join("\n");
+      const parsed = parseEmailMessages(bytes(mailbox), true);
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0]?.body).toContain("From alice@example.com wrote:");
+      expect(parsed.messages[0]?.body).toContain("After.");
+    });
+
+    it("splits on a bare sender token with neither an address nor a date", () => {
+      const mailbox = [
+        "From MAILER-DAEMON",
+        "From: postmaster@example.com",
+        "Subject: bounce",
+        "",
+        "Delivery failed.",
+        "",
+      ].join("\n");
+      const parsed = parseEmailMessages(bytes(mailbox), true);
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0]?.subject).toBe("bounce");
+    });
+
+    it("parses encodings that legitimately embed control bytes", () => {
+      // ISO-2022-JP switches charsets with ESC; UTF-16LE is full of NUL bytes.
+      const iso2022 = rawMessage(
+        [
+          "From: jp@example.com",
+          "Content-Type: text/plain; charset=iso-2022-jp",
+          "Content-Transfer-Encoding: 8bit",
+        ],
+        // ESC $ B then JIS X 0208 for 日 (0x46 0x7C) and 本 (0x4B 0x5C), then ESC ( B.
+        Uint8Array.from([0x1b, 0x24, 0x42, 0x46, 0x7c, 0x4b, 0x5c, 0x1b, 0x28, 0x42]),
+      );
+      expect(parseEmailMessages(iso2022, false).messages[0]?.body).toContain("日本");
+
+      const utf16 = rawMessage(
+        [
+          "From: u@example.com",
+          "Content-Type: text/plain; charset=utf-16le",
+          "Content-Transfer-Encoding: base64",
+        ],
+        bytes(Buffer.from("hello there", "utf16le").toString("base64")),
+      );
+      expect(parseEmailMessages(utf16, false).messages[0]?.body).toContain("hello there");
+    });
+
+    it("stays linear on balanced script regions at scale", () => {
+      const html = [
+        "From: h@example.com",
+        "Content-Type: text/html; charset=utf-8",
+        "",
+        `${"<script>x</script>".repeat(60_000)}<p>visible tail</p>`,
+        "",
+      ].join("\r\n");
+      const started = Date.now();
+      const body = parseEmailMessages(bytes(html), false).messages[0]?.body ?? "";
+      expect(body).toContain("visible tail");
+      expect(Date.now() - started).toBeLessThan(3_000);
+    });
+
+    it("stays linear on many unclosed style openers", () => {
+      const html = [
+        "From: h@example.com",
+        "Content-Type: text/html; charset=utf-8",
+        "",
+        `${"<style>".repeat(120_000)}<p>visible tail</p>`,
+        "",
+      ].join("\r\n");
+      const started = Date.now();
+      const body = parseEmailMessages(bytes(html), false).messages[0]?.body ?? "";
+      expect(body).toContain("visible tail");
+      expect(Date.now() - started).toBeLessThan(3_000);
+    });
+
+    it("keeps markup scanning aligned when lowercasing would change length", () => {
+      // U+0130 lowercases to two code points, which would shift every later index.
+      const html = [
+        "From: h@example.com",
+        "Content-Type: text/html; charset=utf-8",
+        "",
+        `${"İ".repeat(20)}<script>hidden()</script><p>visible tail</p>`,
+        "",
+      ].join("\r\n");
+      const body = parseEmailMessages(bytes(html), false).messages[0]?.body ?? "";
+      expect(body).toContain("visible tail");
+      expect(body).not.toContain("hidden()");
+    });
+  });
+});

--- a/packages/adapters/src/email-parser.test.ts
+++ b/packages/adapters/src/email-parser.test.ts
@@ -97,6 +97,15 @@ const rawMessage = (headerLines: readonly string[], body: Uint8Array): Uint8Arra
   return combined;
 };
 
+/**
+ * Builds a one-part HTML message around an inner fragment.
+ *
+ * @param inner - HTML body content.
+ * @returns Complete message bytes.
+ */
+const htmlMessage = (inner: string): string =>
+  ["From: h@example.com", "Content-Type: text/html; charset=utf-8", "", inner, ""].join("\r\n");
+
 describe("mail material parsing", () => {
   it("renders a simple message with decoded headers and body", () => {
     const parsed = parseEmailMessages(bytes(SIMPLE), false);
@@ -590,6 +599,69 @@ describe("mail material parsing", () => {
       const body = parseEmailMessages(bytes(html), false).messages[0]?.body ?? "";
       expect(body).toContain("visible tail");
       expect(Date.now() - started).toBeLessThan(3_000);
+    });
+
+    it("splits a date-less separator that carries trailing whitespace", () => {
+      for (const separator of ["From x@y ", "From x@y  ", "From MAILER-DAEMON ", "From - "]) {
+        const mailbox = [
+          separator,
+          "From: A <a@example.com>",
+          "Subject: one",
+          "",
+          "First body.",
+          "",
+          "From b@example.com",
+          "From: B <b@example.com>",
+          "Subject: two",
+          "",
+          "Second body.",
+          "",
+        ].join("\n");
+        const parsed = parseEmailMessages(bytes(mailbox), true);
+        expect(parsed.messages.length, separator).toBe(2);
+        expect(parsed.messages[0]?.body, separator).not.toContain("Subject: two");
+      }
+    });
+
+    it("does not split on prose whose digit appears later in the line", () => {
+      const mailbox = [
+        "From a@example.com Fri Sep 11 10:00:00 2026",
+        "From: A <a@example.com>",
+        "Subject: one",
+        "",
+        "Before.",
+        "From the desk of Bob, 2nd floor",
+        "After.",
+        "",
+      ].join("\n");
+      const parsed = parseEmailMessages(bytes(mailbox), true);
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0]?.body).toContain("From the desk of Bob, 2nd floor");
+      expect(parsed.messages[0]?.body).toContain("After.");
+    });
+
+    it("lets no commented-out opener swallow visible text", () => {
+      for (const inner of [
+        "<!-- <script> --><script>LEAK</script>VISIBLE",
+        "<!-- <script> -->VISIBLE<p>TAIL</p><script>LEAK</script>",
+        "<!-- <script> -->A<!-- <script> -->VISIBLE<script>LEAK</script>",
+      ]) {
+        const body = parseEmailMessages(bytes(htmlMessage(inner)), false).messages[0]?.body ?? "";
+        expect(body, inner).toContain("VISIBLE");
+        expect(body, inner).not.toContain("LEAK");
+      }
+    });
+
+    it("matches element names at the tag boundary instead of by prefix", () => {
+      for (const inner of [
+        "<scripty>LEAK</scripty>VISIBLE",
+        "<scripts>LEAK</scripts>VISIBLE",
+        "<stylesheet>LEAK</stylesheet>VISIBLE",
+      ]) {
+        const body = parseEmailMessages(bytes(htmlMessage(inner)), false).messages[0]?.body ?? "";
+        expect(body, inner).toContain("LEAK");
+        expect(body, inner).toContain("VISIBLE");
+      }
     });
 
     it("keeps markup scanning aligned when lowercasing would change length", () => {

--- a/packages/adapters/src/email-parser.test.ts
+++ b/packages/adapters/src/email-parser.test.ts
@@ -601,6 +601,50 @@ describe("mail material parsing", () => {
       expect(Date.now() - started).toBeLessThan(3_000);
     });
 
+    it("splits every date shape real writers emit", () => {
+      for (const separator of [
+        "From x@y\t",
+        "From x@y\t ",
+        "From x@y  Fri Sep 11 02:31:00 2026",
+        "From x@y  2026-09-11 02:31:00",
+        "From x@y Friday, 11 Sep 2026 02:31:00 +0000",
+        "From x@y 11-Sep-2026 02:31:00",
+        "From x@y 11/09/2026 02:31:00",
+        "From x@y 02:31:00 2026",
+        "From x@y 20260911",
+        "From x@y 1789000000",
+        "From x@y <1789000000>",
+      ]) {
+        const mailbox = [
+          separator,
+          "From: A <a@example.com>",
+          "Subject: one",
+          "",
+          "First body.",
+          "",
+          "From b@example.com Fri Sep 11 10:00:00 2026",
+          "From: B <b@example.com>",
+          "Subject: two",
+          "",
+          "Second body.",
+          "",
+        ].join("\n");
+        const parsed = parseEmailMessages(bytes(mailbox), true);
+        expect(parsed.messages.length, separator).toBe(2);
+        expect(parsed.messages[1]?.subject, separator).toBe("two");
+      }
+    });
+
+    it("keeps visible text when raw-text markup contains a comment opener", () => {
+      for (const inner of [
+        "<script>\n<!-- hide\n</script>VISIBLE-CONTENT",
+        "<script>if(a<!--b){c()}</script>VISIBLE-CONTENT",
+      ]) {
+        const body = parseEmailMessages(bytes(htmlMessage(inner)), false).messages[0]?.body ?? "";
+        expect(body, inner).toContain("VISIBLE-CONTENT");
+      }
+    });
+
     it("splits a date-less separator that carries trailing whitespace", () => {
       for (const separator of ["From x@y ", "From x@y  ", "From MAILER-DAEMON ", "From - "]) {
         const mailbox = [

--- a/packages/adapters/src/email-parser.ts
+++ b/packages/adapters/src/email-parser.ts
@@ -47,17 +47,19 @@ const HEADER_LINE = /^([!-9;-~]+):\s*(.*)$/u;
  * silently merge every message written in another shape, so the rule keeps the sender
  * token and the remainder and lets the caller judge the remainder instead.
  */
-const MBOX_SEPARATOR = /^From (\S+)(?: (.*))?$/u;
+const MBOX_SEPARATOR = /^From (\S+)(?:[ \t]+(.*))?$/u;
 
 /**
  * Matches the date part of an mbox `from_` line at its start.
  *
- * Weekday-month-day (ctime), day-month (RFC 2822), ISO 8601, and epoch seconds are the
- * shapes writers emit. Requiring the date at the start rejects prose that merely contains
- * a digit later, such as "From the desk of Bob, 2nd floor".
+ * Writers emit ctime (`Fri Sep  1 10:00:00 2026`), day-month (`11 Sep 2026`), hyphenated
+ * or slashed dates, ISO 8601, a compact date, a leading time, or epoch seconds, sometimes
+ * after a padded sender. The shape must begin where the remainder begins, so prose that
+ * merely contains a digit later (`From the desk of Bob, 2nd floor`) and a bare year
+ * (`From 2026 we will change everything.`) stay body text.
  */
 const MBOX_DATE =
-  /^(?:[A-Z][a-z]{2},? )?(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)|\d{1,2} )|^\d{4}-\d{2}-\d{2}|^\d{9,}/u;
+  /^[ \t]*(?:[A-Za-z]{3,},?[ \t]+)?(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[ \t]+\d{1,2}|\d{1,2}[ \t]+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)|\d{1,2}[-/]\d{1,2}[-/]\d{2,4}|\d{4}-\d{2}-\d{2}|\d{8}|\d{1,2}:\d{2}|\d{9,}|<\d+>)/u;
 
 /**
  * Maps bytes to a code-point-preserving string so structural scanning never confuses a
@@ -225,7 +227,7 @@ const decodeHeaderWords = (value: string): string =>
     );
 
 /**
- * Removes `script` and `style` element regions in one linear pass.
+ * Removes comments plus `script` and `style` element regions in one linear pass.
  *
  * A back-reference regular expression is quadratic when a document holds many openers and
  * no closer, and re-searching for a closer each time is quadratic for the same reason, so
@@ -234,8 +236,13 @@ const decodeHeaderWords = (value: string): string =>
  * are compared instead of lowercasing the document, because lowercasing can change a
  * string's length and misalign every later index.
  *
+ * Comments and raw-text elements are handled in the same scan because their order matters:
+ * a commented-out opener must not act as markup, while a `<!--` inside `script` or `style`
+ * is script text rather than a comment. Removing comments in a separate earlier pass would
+ * let an unclosed `<!--` inside a script swallow every later visible character.
+ *
  * @param html - Raw HTML text.
- * @returns HTML with script and style regions removed.
+ * @returns HTML with comments and script and style regions removed.
  */
 const removeScriptAndStyle = (html: string): string => {
   const noCloserLeft: Record<"script" | "style", boolean> = { script: false, style: false };
@@ -245,6 +252,14 @@ const removeScriptAndStyle = (html: string): string => {
     const open = html.indexOf("<", index);
     if (open === -1) return result + html.slice(index);
     const head = html.slice(open, open + 9).toLowerCase();
+    if (head.startsWith("<!--")) {
+      result += html.slice(index, open);
+      const end = html.indexOf("-->", open + 4);
+      // An unterminated comment hides the rest of the document, as HTML defines it.
+      if (end === -1) return result;
+      index = end + 3;
+      continue;
+    }
     // The element name must end at the tag boundary, so <scripty> is not <script>.
     const named = (name: string): boolean => {
       if (!head.startsWith(`<${name}`)) return false;
@@ -293,25 +308,6 @@ const removeScriptAndStyle = (html: string): string => {
   return result;
 };
 
-/**
- * Removes HTML comments in one linear pass.
- *
- * @param html - Raw HTML text.
- * @returns HTML with comment regions removed.
- */
-const removeComments = (html: string): string => {
-  let result = "";
-  let index = 0;
-  for (;;) {
-    const start = html.indexOf("<!--", index);
-    if (start === -1) return result + html.slice(index);
-    result += html.slice(index, start);
-    const end = html.indexOf("-->", start + 4);
-    if (end === -1) return result;
-    index = end + 3;
-  }
-};
-
 /** Element names recognized as markup, so prose angle brackets are never removed. */
 const HTML_TAGS =
   /<\/?(?:a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|big|blink|blockquote|body|br|button|canvas|caption|center|cite|code|col|colgroup|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fieldset|figcaption|figure|font|footer|form|h[1-6]|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|main|map|mark|marquee|menu|meta|meter|nav|nobr|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|section|select|slot|small|source|span|strike|strong|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\b[^<>]*>/giu;
@@ -329,8 +325,7 @@ const decodeNumericEntities = (text: string): string =>
 
 const stripHtml = (html: string): string =>
   decodeNumericEntities(
-    // Comments are removed first so a commented-out opener cannot swallow real text.
-    removeScriptAndStyle(removeComments(html))
+    removeScriptAndStyle(html)
       .replaceAll(/<br\s*\/?>/giu, "\n")
       .replaceAll(/<\/(p|div|tr|li|h[1-6])>/giu, "\n")
       .replaceAll(HTML_TAGS, " "),

--- a/packages/adapters/src/email-parser.ts
+++ b/packages/adapters/src/email-parser.ts
@@ -50,6 +50,16 @@ const HEADER_LINE = /^([!-9;-~]+):\s*(.*)$/u;
 const MBOX_SEPARATOR = /^From (\S+)(?: (.*))?$/u;
 
 /**
+ * Matches the date part of an mbox `from_` line at its start.
+ *
+ * Weekday-month-day (ctime), day-month (RFC 2822), ISO 8601, and epoch seconds are the
+ * shapes writers emit. Requiring the date at the start rejects prose that merely contains
+ * a digit later, such as "From the desk of Bob, 2nd floor".
+ */
+const MBOX_DATE =
+  /^(?:[A-Z][a-z]{2},? )?(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)|\d{1,2} )|^\d{4}-\d{2}-\d{2}|^\d{9,}/u;
+
+/**
  * Maps bytes to a code-point-preserving string so structural scanning never confuses a
  * part's raw bytes with a decoded charset.
  *
@@ -235,11 +245,13 @@ const removeScriptAndStyle = (html: string): string => {
     const open = html.indexOf("<", index);
     if (open === -1) return result + html.slice(index);
     const head = html.slice(open, open + 9).toLowerCase();
-    const tag: "script" | "style" | "" = head.startsWith("<script")
-      ? "script"
-      : head.startsWith("<style")
-        ? "style"
-        : "";
+    // The element name must end at the tag boundary, so <scripty> is not <script>.
+    const named = (name: string): boolean => {
+      if (!head.startsWith(`<${name}`)) return false;
+      const next = head.charAt(name.length + 1);
+      return next === "" || next === ">" || next === "/" || /\s/u.test(next);
+    };
+    const tag: "script" | "style" | "" = named("script") ? "script" : named("style") ? "style" : "";
     if (tag === "") {
       result += html.slice(index, open + 1);
       index = open + 1;
@@ -252,7 +264,14 @@ const removeScriptAndStyle = (html: string): string => {
       for (;;) {
         const candidate = html.indexOf("<", cursor);
         if (candidate === -1) break;
-        if (html.slice(candidate, candidate + closeTag.length).toLowerCase() === closeTag) {
+        const candidateHead = html.slice(candidate, candidate + closeTag.length + 1).toLowerCase();
+        if (
+          candidateHead.startsWith(closeTag) &&
+          (() => {
+            const next = candidateHead.charAt(closeTag.length);
+            return next === "" || next === ">" || next === "/" || /\s/u.test(next);
+          })()
+        ) {
           close = candidate;
           break;
         }
@@ -310,7 +329,8 @@ const decodeNumericEntities = (text: string): string =>
 
 const stripHtml = (html: string): string =>
   decodeNumericEntities(
-    removeComments(removeScriptAndStyle(html))
+    // Comments are removed first so a commented-out opener cannot swallow real text.
+    removeScriptAndStyle(removeComments(html))
       .replaceAll(/<br\s*\/?>/giu, "\n")
       .replaceAll(/<\/(p|div|tr|li|h[1-6])>/giu, "\n")
       .replaceAll(HTML_TAGS, " "),
@@ -619,11 +639,13 @@ const splitMailbox = (text: string): readonly string[] => {
   for (const line of text.split(/\r\n|\r|\n/u)) {
     const isFirst = !sawSeparator && current === undefined;
     const separator = MBOX_SEPARATOR.exec(line);
-    // A separator has either no remainder or a date-like remainder carrying a digit, so
-    // every writer's date format separates while prose ("From now on ...") and an address
-    // in a quotation ("From alice@example.com wrote:") stay body text.
+    // A separator has either no remainder or a remainder that starts with a date, so every
+    // writer's date format separates while prose ("From now on ...", "From the desk of
+    // Bob, 2nd floor") and a quoted address ("From alice@example.com wrote:") stay text.
     const remainder = separator?.[2];
-    const isSeparator = separator !== null && (remainder === undefined || /\d/u.test(remainder));
+    const isSeparator =
+      separator !== null &&
+      (remainder === undefined || remainder.trim() === "" || MBOX_DATE.test(remainder));
     if (line.startsWith("From ") && (isFirst || isSeparator)) {
       if (current !== undefined) messages.push(current.join("\n"));
       current = [];

--- a/packages/adapters/src/email-parser.ts
+++ b/packages/adapters/src/email-parser.ts
@@ -1,0 +1,692 @@
+import { DistillyError } from "@distilly/protocol";
+
+/** One decoded message extracted from an RFC 5322 message or an mbox mailbox. */
+export interface ParsedEmailMessage {
+  readonly from?: string;
+  readonly to?: string;
+  readonly cc?: string;
+  readonly date?: string;
+  readonly subject?: string;
+  readonly body: string;
+}
+
+/** Decoded mailbox ready for deterministic rendering. */
+export interface ParsedEmail {
+  readonly messages: readonly ParsedEmailMessage[];
+  readonly skippedAttachments: number;
+  readonly undecodableParts: number;
+}
+
+/** Maximum multipart nesting depth before the source is rejected as unrepresentable. */
+const MAXIMUM_NESTING = 16;
+
+/** Media type families that never carry distillable human text. */
+const BINARY_MEDIA_PREFIXES = Object.freeze([
+  "application/",
+  "audio/",
+  "image/",
+  "video/",
+  "font/",
+  "model/",
+]);
+
+const invalidInput = (message: string, fieldPath?: string): DistillyError =>
+  new DistillyError({
+    code: "invalid_input",
+    message,
+    retryable: false,
+    ...(fieldPath === undefined ? {} : { fieldPath }),
+  });
+
+const HEADER_LINE = /^([!-9;-~]+):\s*(.*)$/u;
+/**
+ * Splits an mbox `from_` line into its sender token and the remainder.
+ *
+ * Writers format the date as ctime, RFC 2822, ISO 8601, epoch seconds, or omit it, and
+ * ctime pads single-digit days with a second space. Matching one date shape would
+ * silently merge every message written in another shape, so the rule keeps the sender
+ * token and the remainder and lets the caller judge the remainder instead.
+ */
+const MBOX_SEPARATOR = /^From (\S+)(?: (.*))?$/u;
+
+/**
+ * Maps bytes to a code-point-preserving string so structural scanning never confuses a
+ * part's raw bytes with a decoded charset.
+ *
+ * Chunked to avoid an argument-count limit on large mailboxes.
+ *
+ * @param bytes - Raw source bytes.
+ * @returns One character per byte, each in U+0000–U+00FF.
+ */
+const bytesToBinaryString = (bytes: Uint8Array): string => {
+  const chunk = 8192;
+  const parts: string[] = [];
+  for (let index = 0; index < bytes.length; index += chunk) {
+    parts.push(String.fromCharCode(...bytes.subarray(index, index + chunk)));
+  }
+  return parts.join("");
+};
+
+/**
+ * Reverses {@link bytesToBinaryString} for one part body.
+ *
+ * @param text - Binary string produced from bytes.
+ * @returns The original bytes.
+ */
+const binaryStringToBytes = (text: string): Uint8Array => {
+  const bytes = new Uint8Array(text.length);
+  for (let index = 0; index < text.length; index += 1) {
+    bytes[index] = text.charCodeAt(index) & 0xff;
+  }
+  return bytes;
+};
+
+/**
+ * Reports whether decoded text carries control characters that prose never uses.
+ *
+ * The check runs on decoded text, not raw bytes, so an encoding that legitimately embeds
+ * control bytes (ISO-2022-JP escapes, UTF-16 NULs) is judged by what it decodes to.
+ *
+ * @param text - Decoded candidate text.
+ * @returns True when the payload looks binary.
+ */
+const looksBinary = (text: string): boolean => {
+  for (const character of text) {
+    const code = character.codePointAt(0)!;
+    if (code === 0x09 || code === 0x0a || code === 0x0d || code === 0x0c || code === 0x0b) {
+      continue;
+    }
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
+};
+
+/**
+ * Decodes one part body with its declared charset, then deterministic fallbacks.
+ *
+ * Valid multi-byte UTF-8 wins over a declaration only when that declaration is one of
+ * the labels senders routinely apply to UTF-8 by mistake. A specific legacy declaration
+ * such as shift_jis or gb18030 is honoured first, because those encodings have byte
+ * pairs that are also valid UTF-8 and guessing UTF-8 there would corrupt them.
+ *
+ * @param bytes - Raw part bytes after transfer decoding.
+ * @param charset - Declared charset name, if any.
+ * @returns Decoded text, or undefined when no candidate decoder exists.
+ */
+const COMMON_UTF8_MISLABELS = new Set([
+  "",
+  "ascii",
+  "charset",
+  "cp1252",
+  "default",
+  "iso-8859-1",
+  "latin-1",
+  "latin1",
+  "unknown-8bit",
+  "us-ascii",
+  "utf-8",
+  "utf8",
+  "windows-1252",
+  "x-unknown",
+]);
+
+const decodeCharset = (bytes: Uint8Array, charset: string | undefined): string | undefined => {
+  const label = (charset ?? "utf-8").trim().toLowerCase().replaceAll('"', "");
+  if (COMMON_UTF8_MISLABELS.has(label) && bytes.some((byte) => byte >= 0x80)) {
+    try {
+      const utf8 = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+      if ([...utf8].some((character) => character.codePointAt(0)! > 0x7f)) return utf8;
+    } catch {
+      // Not UTF-8, so the declared charset decides.
+    }
+  }
+  const candidates = [...new Set([label, "utf-8", "windows-1252"])].filter(
+    (candidate) => candidate.length > 0,
+  );
+  for (const candidate of candidates) {
+    try {
+      return new TextDecoder(candidate, { fatal: true }).decode(bytes);
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+};
+
+const fromBase64 = (value: string): Uint8Array | undefined => {
+  const cleaned = value.replaceAll(/\s/gu, "");
+  if (cleaned.length === 0) return new Uint8Array();
+  if (!/^[A-Za-z0-9+/]*={0,2}$/u.test(cleaned)) return undefined;
+  return Uint8Array.from(Buffer.from(cleaned, "base64"));
+};
+
+const fromQuotedPrintable = (value: string): Uint8Array => {
+  const bytes: number[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]!;
+    if (character === "=") {
+      const next = value[index + 1];
+      if (next === "\n") {
+        index += 1;
+        continue;
+      }
+      if (next === "\r" && value[index + 2] === "\n") {
+        index += 2;
+        continue;
+      }
+      const hex = value.slice(index + 1, index + 3);
+      if (/^[0-9A-Fa-f]{2}$/u.test(hex)) {
+        bytes.push(Number.parseInt(hex, 16));
+        index += 2;
+        continue;
+      }
+      bytes.push(0x3d);
+      continue;
+    }
+    bytes.push(character.charCodeAt(0) & 0xff);
+  }
+  return Uint8Array.from(bytes);
+};
+
+/**
+ * Decodes RFC 2047 encoded words inside a header value.
+ *
+ * Whitespace between two adjacent encoded words is not part of the value, so it is
+ * removed instead of surviving as a visible separator.
+ *
+ * @param value - Raw header value.
+ * @returns Header text with encoded words decoded, or the input when malformed.
+ */
+const decodeHeaderWords = (value: string): string =>
+  value
+    // Whitespace between two adjacent encoded words is not part of the value, so it is
+    // collapsed before decoding rather than left as a visible separator.
+    .replaceAll(/(=\?[^?]+\?[BbQq]\?[^?]*\?=)\s+(?==\?[^?]+\?[BbQq]\?)/gu, "$1")
+    .replaceAll(
+      /=\?([^?]+)\?([BbQq])\?([^?]*)\?=/gu,
+      (match, charset: string, encoding: string, payload: string) => {
+        const bytes =
+          encoding.toUpperCase() === "B"
+            ? fromBase64(payload)
+            : fromQuotedPrintable(payload.replaceAll("_", " "));
+        if (bytes === undefined) return match;
+        return decodeCharset(bytes, charset) ?? match;
+      },
+    );
+
+/**
+ * Removes `script` and `style` element regions in one linear pass.
+ *
+ * A back-reference regular expression is quadratic when a document holds many openers and
+ * no closer, and re-searching for a closer each time is quadratic for the same reason, so
+ * each tag type searches for its closer at most once: the first failed search proves no
+ * closer remains anywhere, and later openers then drop only their own tag. Short slices
+ * are compared instead of lowercasing the document, because lowercasing can change a
+ * string's length and misalign every later index.
+ *
+ * @param html - Raw HTML text.
+ * @returns HTML with script and style regions removed.
+ */
+const removeScriptAndStyle = (html: string): string => {
+  const noCloserLeft: Record<"script" | "style", boolean> = { script: false, style: false };
+  let result = "";
+  let index = 0;
+  while (index < html.length) {
+    const open = html.indexOf("<", index);
+    if (open === -1) return result + html.slice(index);
+    const head = html.slice(open, open + 9).toLowerCase();
+    const tag: "script" | "style" | "" = head.startsWith("<script")
+      ? "script"
+      : head.startsWith("<style")
+        ? "style"
+        : "";
+    if (tag === "") {
+      result += html.slice(index, open + 1);
+      index = open + 1;
+      continue;
+    }
+    const closeTag = `</${tag}`;
+    let close = -1;
+    if (!noCloserLeft[tag]) {
+      let cursor = open + tag.length + 1;
+      for (;;) {
+        const candidate = html.indexOf("<", cursor);
+        if (candidate === -1) break;
+        if (html.slice(candidate, candidate + closeTag.length).toLowerCase() === closeTag) {
+          close = candidate;
+          break;
+        }
+        cursor = candidate + 1;
+      }
+      if (close === -1) noCloserLeft[tag] = true;
+    }
+    result += html.slice(index, open);
+    if (close === -1) {
+      // No closer anywhere, so only the opener tag is markup; trailing prose survives.
+      const openerEnd = html.indexOf(">", open);
+      if (openerEnd === -1) return result;
+      index = openerEnd + 1;
+      continue;
+    }
+    const closerEnd = html.indexOf(">", close);
+    index = closerEnd === -1 ? html.length : closerEnd + 1;
+  }
+  return result;
+};
+
+/**
+ * Removes HTML comments in one linear pass.
+ *
+ * @param html - Raw HTML text.
+ * @returns HTML with comment regions removed.
+ */
+const removeComments = (html: string): string => {
+  let result = "";
+  let index = 0;
+  for (;;) {
+    const start = html.indexOf("<!--", index);
+    if (start === -1) return result + html.slice(index);
+    result += html.slice(index, start);
+    const end = html.indexOf("-->", start + 4);
+    if (end === -1) return result;
+    index = end + 3;
+  }
+};
+
+/** Element names recognized as markup, so prose angle brackets are never removed. */
+const HTML_TAGS =
+  /<\/?(?:a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|big|blink|blockquote|body|br|button|canvas|caption|center|cite|code|col|colgroup|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fieldset|figcaption|figure|font|footer|form|h[1-6]|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|main|map|mark|marquee|menu|meta|meter|nav|nobr|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|section|select|slot|small|source|span|strike|strong|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr)\b[^<>]*>/giu;
+
+const decodeNumericEntities = (text: string): string =>
+  text
+    .replaceAll(/&#(\d+);/gu, (match, code: string) => {
+      const value = Number.parseInt(code, 10);
+      return value >= 0 && value <= 0x10ffff ? String.fromCodePoint(value) : match;
+    })
+    .replaceAll(/&#[xX]([0-9A-Fa-f]+);/gu, (match, code: string) => {
+      const value = Number.parseInt(code, 16);
+      return value >= 0 && value <= 0x10ffff ? String.fromCodePoint(value) : match;
+    });
+
+const stripHtml = (html: string): string =>
+  decodeNumericEntities(
+    removeComments(removeScriptAndStyle(html))
+      .replaceAll(/<br\s*\/?>/giu, "\n")
+      .replaceAll(/<\/(p|div|tr|li|h[1-6])>/giu, "\n")
+      .replaceAll(HTML_TAGS, " "),
+  )
+    .replaceAll(/&nbsp;/giu, " ")
+    .replaceAll(/&lt;/giu, "<")
+    .replaceAll(/&gt;/giu, ">")
+    .replaceAll(/&quot;/giu, '"')
+    .replaceAll(/&#39;|&apos;/giu, "'")
+    .replaceAll(/&amp;/giu, "&");
+
+/**
+ * Reports whether text has at least one visible character.
+ *
+ * @param text - Candidate text.
+ * @returns True when something other than whitespace or formatting characters remains.
+ */
+const hasVisibleText = (text: string): boolean =>
+  text.replaceAll(/\s/gu, "").replaceAll(/\p{Cf}/gu, "").length > 0;
+
+const normalizeLines = (text: string): string =>
+  text
+    .split(/\r\n|\r|\n/u)
+    .map((line) => line.replaceAll(/[ \t]+/gu, " ").replaceAll(/^ +| +$/gu, ""))
+    .join("\n")
+    .replaceAll(/\n{3,}/gu, "\n\n")
+    .replaceAll(/^\n+|\n+$/gu, "");
+
+/**
+ * Decodes a raw (non-RFC-2047) header value that carries 8-bit bytes.
+ *
+ * A header is otherwise a byte-preserving string, so an unencoded UTF-8 subject would
+ * surface as mojibake. ASCII values take the fast path unchanged.
+ *
+ * @param value - Raw header value as a byte-preserving string.
+ * @returns The decoded value, or the input when it is already ASCII or undecodable.
+ */
+const decodeRawHeaderValue = (value: string): string => {
+  if (![...value].some((character) => character.codePointAt(0)! > 0x7f)) return value;
+  return decodeCharset(binaryStringToBytes(value), undefined) ?? value;
+};
+
+interface HeaderBlock {
+  readonly headers: ReadonlyMap<string, string>;
+  readonly bodyStart: number;
+}
+
+/**
+ * Splits an entity into its unfolded header map and the offset where its body starts.
+ *
+ * Leading blank lines are skipped so a message whose first header is indented still
+ * yields its headers instead of silently losing them.
+ *
+ * @param text - Entity text including headers.
+ * @returns Header map plus body offset, or undefined when the entity has no header block.
+ */
+const readHeaders = (text: string): HeaderBlock | undefined => {
+  const leading = /^(?:[ \t]*\r?\n)+/u.exec(text);
+  const trimOffset = leading === null ? 0 : leading[0].length;
+  const trimmed = text.slice(trimOffset);
+  const separator = /\r\n\r\n|\n\n|\r\r|\r\n\n|\n\r\n/u.exec(trimmed);
+  if (separator === null) return undefined;
+  const unfolded = trimmed.slice(0, separator.index).replaceAll(/\r?\n[ \t]+/gu, " ");
+  const headers = new Map<string, string>();
+  for (const line of unfolded.split(/\r\n|\r|\n/u)) {
+    const match = HEADER_LINE.exec(line.trimStart());
+    if (match === null) continue;
+    const name = match[1]!.toLowerCase();
+    const value = decodeRawHeaderValue(match[2]!.trim());
+    headers.set(name, headers.has(name) ? `${headers.get(name)}, ${value}` : value);
+  }
+  return { headers, bodyStart: trimOffset + separator.index + separator[0].length };
+};
+
+const parameter = (value: string | undefined, name: string): string | undefined => {
+  if (value === undefined) return undefined;
+  const pattern = new RegExp(`(?:^|;)\\s*${name}\\s*=\\s*("[^"]*"|[^;\\s]+)`, "iu");
+  const match = pattern.exec(value);
+  if (match === null) return undefined;
+  return match[1]!.trim().replaceAll(/^"|"$/gu, "");
+};
+
+const mediaTypeOf = (value: string): string =>
+  (value.split(";")[0] ?? "text/plain").trim().toLowerCase() || "text/plain";
+
+const isBinaryMediaType = (mediaType: string | undefined): boolean => {
+  if (mediaType === undefined) return false;
+  if (mediaType.startsWith("text/") || mediaType === "message/rfc822") return false;
+  return (
+    BINARY_MEDIA_PREFIXES.some((prefix) => mediaType.startsWith(prefix)) ||
+    mediaType !== "text/plain"
+  );
+};
+
+interface MimePart {
+  readonly mediaType?: string;
+  readonly charset?: string;
+  readonly encoding: string;
+  readonly boundary?: string;
+  readonly isAttachment: boolean;
+  readonly body: string;
+}
+
+const parseEntity = (text: string): MimePart | undefined => {
+  const header = readHeaders(text);
+  if (header === undefined) return undefined;
+  const contentType = header.headers.get("content-type");
+  const declaration = contentType === undefined ? undefined : mediaTypeOf(contentType);
+  const charset = parameter(contentType, "charset");
+  const boundary = parameter(contentType, "boundary");
+  const disposition = header.headers.get("content-disposition");
+  const isAttachment =
+    disposition !== undefined &&
+    /^\s*attachment\b/iu.test(disposition) &&
+    declaration !== undefined &&
+    !declaration.startsWith("multipart/");
+  return {
+    ...(declaration === undefined ? {} : { mediaType: declaration }),
+    ...(charset === undefined ? {} : { charset }),
+    encoding: (header.headers.get("content-transfer-encoding") ?? "7bit").trim().toLowerCase(),
+    ...(boundary === undefined ? {} : { boundary }),
+    isAttachment,
+    body: text.slice(header.bodyStart),
+  };
+};
+
+const decodePartBytes = (part: MimePart): Uint8Array | undefined => {
+  if (part.encoding === "base64") return fromBase64(part.body);
+  if (part.encoding === "quoted-printable") return fromQuotedPrintable(part.body);
+  if (["7bit", "8bit", "binary", ""].includes(part.encoding)) {
+    return binaryStringToBytes(part.body);
+  }
+  return undefined;
+};
+
+const splitParts = (body: string, boundary: string): readonly string[] => {
+  const delimiter = `--${boundary}`;
+  const segments: string[] = [];
+  let current: string[] | undefined;
+  for (const line of body.split(/\r\n|\r|\n/u)) {
+    // RFC 2046 allows transport padding (whitespace) after the delimiter.
+    const trimmed = line.replaceAll(/[ \t]+$/gu, "");
+    if (trimmed === delimiter || trimmed === `${delimiter}--`) {
+      if (current !== undefined) segments.push(current.join("\n"));
+      current = trimmed === `${delimiter}--` ? undefined : [];
+      continue;
+    }
+    current?.push(line);
+  }
+  if (current !== undefined) segments.push(current.join("\n"));
+  return segments;
+};
+
+/**
+ * Keeps the first alternative that carries visible text, so an empty one cannot win.
+ *
+ * @param current - Alternative already chosen, if any.
+ * @param candidate - New alternative to consider.
+ * @returns The alternative to keep.
+ */
+const pickText = (current: string | undefined, candidate: string): string | undefined => {
+  if (current !== undefined && hasVisibleText(current)) return current;
+  return hasVisibleText(candidate) ? candidate : current;
+};
+
+interface CollectedBody {
+  readonly text?: string;
+  readonly html?: string;
+  readonly skippedAttachments: number;
+  readonly undecodableParts: number;
+  readonly depthExceeded: boolean;
+}
+
+const collectBody = (part: MimePart, depth: number): CollectedBody => {
+  if (depth >= MAXIMUM_NESTING) {
+    return { skippedAttachments: 0, undecodableParts: 0, depthExceeded: true };
+  }
+  const declaration = part.mediaType;
+  if (declaration !== undefined && declaration.startsWith("multipart/")) {
+    if (part.boundary === undefined || part.boundary.length === 0) {
+      return { skippedAttachments: 0, undecodableParts: 1, depthExceeded: false };
+    }
+    let text: string | undefined;
+    let html: string | undefined;
+    let skippedAttachments = 0;
+    let undecodableParts = 0;
+    let depthExceeded = false;
+    for (const segment of splitParts(part.body, part.boundary)) {
+      if (segment.trim().length === 0) continue;
+      // A segment that opens with a header line but never terminates its header block is
+      // an empty-bodied part, not prose. Rendering its headers as the body would publish
+      // "Content-Type: ..." as evidence and hide a readable alternative.
+      const firstLine = segment.trimStart().split(/\r?\n/u, 1)[0] ?? "";
+      if (parseEntity(segment) === undefined && HEADER_LINE.test(firstLine)) {
+        undecodableParts += 1;
+        continue;
+      }
+      const nested = parseEntity(segment) ?? {
+        // A part with no header block at all still carries bytes; treat it as an untyped
+        // body so the binary sniff can reject it instead of dropping it silently.
+        encoding: "7bit",
+        isAttachment: false,
+        body: segment,
+      };
+      if (nested.isAttachment) {
+        skippedAttachments += 1;
+        continue;
+      }
+      if (nested.mediaType?.startsWith("multipart/") === true) {
+        const inner = collectBody(nested, depth + 1);
+        text = pickText(text, inner.text ?? "");
+        html ??= inner.html;
+        skippedAttachments += inner.skippedAttachments;
+        undecodableParts += inner.undecodableParts;
+        depthExceeded ||= inner.depthExceeded;
+        continue;
+      }
+      if (isBinaryMediaType(nested.mediaType)) {
+        skippedAttachments += 1;
+        continue;
+      }
+      const bytes = decodePartBytes(nested);
+      if (bytes === undefined) {
+        undecodableParts += 1;
+        continue;
+      }
+      const decoded = decodeCharset(bytes, nested.charset);
+      if (decoded === undefined) {
+        undecodableParts += 1;
+        continue;
+      }
+      // A text declaration does not make content textual, so control characters that
+      // survive decoding are never evidence.
+      if (looksBinary(decoded)) {
+        skippedAttachments += 1;
+        continue;
+      }
+      if (nested.mediaType === "text/html") {
+        html = pickText(html, decoded);
+      } else {
+        text = pickText(text, decoded);
+      }
+    }
+    return {
+      ...(text === undefined ? {} : { text }),
+      ...(html === undefined ? {} : { html }),
+      skippedAttachments,
+      undecodableParts,
+      depthExceeded,
+    };
+  }
+  if (part.isAttachment) {
+    return { skippedAttachments: 1, undecodableParts: 0, depthExceeded: false };
+  }
+  if (isBinaryMediaType(declaration)) {
+    return { skippedAttachments: 1, undecodableParts: 0, depthExceeded: false };
+  }
+  const bytes = decodePartBytes(part);
+  if (bytes === undefined) {
+    return { skippedAttachments: 0, undecodableParts: 1, depthExceeded: false };
+  }
+  const decoded = decodeCharset(bytes, part.charset);
+  if (decoded === undefined) {
+    return { skippedAttachments: 0, undecodableParts: 1, depthExceeded: false };
+  }
+  if (looksBinary(decoded)) {
+    return { skippedAttachments: 1, undecodableParts: 0, depthExceeded: false };
+  }
+  return declaration === "text/html"
+    ? { html: decoded, skippedAttachments: 0, undecodableParts: 0, depthExceeded: false }
+    : { text: decoded, skippedAttachments: 0, undecodableParts: 0, depthExceeded: false };
+};
+
+const renderMessage = (
+  headers: ReadonlyMap<string, string>,
+  collected: CollectedBody,
+): string | undefined => {
+  const plain = collected.text;
+  const fromHtml = collected.html === undefined ? undefined : stripHtml(collected.html);
+  const chosen =
+    plain !== undefined && hasVisibleText(plain)
+      ? plain
+      : fromHtml !== undefined && hasVisibleText(fromHtml)
+        ? fromHtml
+        : undefined;
+  if (chosen === undefined) return undefined;
+  const body = normalizeLines(chosen);
+  if (!hasVisibleText(body)) return undefined;
+  const lines: string[] = [];
+  const push = (label: string, value: string | undefined): void => {
+    if (value !== undefined && value.trim().length > 0) lines.push(`${label}: ${value.trim()}`);
+  };
+  push("From", decodeHeaderWords(headers.get("from") ?? ""));
+  push("To", decodeHeaderWords(headers.get("to") ?? ""));
+  push("Cc", decodeHeaderWords(headers.get("cc") ?? ""));
+  push("Date", headers.get("date"));
+  push("Subject", decodeHeaderWords(headers.get("subject") ?? ""));
+  lines.push("", body);
+  return lines.join("\n");
+};
+
+const splitMailbox = (text: string): readonly string[] => {
+  const messages: string[] = [];
+  let current: string[] | undefined;
+  let sawSeparator = false;
+  for (const line of text.split(/\r\n|\r|\n/u)) {
+    const isFirst = !sawSeparator && current === undefined;
+    const separator = MBOX_SEPARATOR.exec(line);
+    // A separator has either no remainder or a date-like remainder carrying a digit, so
+    // every writer's date format separates while prose ("From now on ...") and an address
+    // in a quotation ("From alice@example.com wrote:") stay body text.
+    const remainder = separator?.[2];
+    const isSeparator = separator !== null && (remainder === undefined || /\d/u.test(remainder));
+    if (line.startsWith("From ") && (isFirst || isSeparator)) {
+      if (current !== undefined) messages.push(current.join("\n"));
+      current = [];
+      sawSeparator = true;
+      continue;
+    }
+    current?.push(line);
+  }
+  if (current !== undefined) messages.push(current.join("\n"));
+  return messages;
+};
+
+/**
+ * Parses one RFC 5322 message, or a whole mbox mailbox, into decoded messages.
+ *
+ * Structural scanning works on the raw bytes so each part is decoded with the charset it
+ * declares; decoding the container first would double-decode 8-bit bodies.
+ *
+ * @param bytes - Raw source bytes.
+ * @param mbox - Whether to split the input on mbox `From ` separator lines.
+ * @returns Decoded messages plus counts of what could not become text.
+ */
+export const parseEmailMessages = (bytes: Uint8Array, mbox: boolean): ParsedEmail => {
+  const text = bytesToBinaryString(bytes);
+  const sources = mbox ? splitMailbox(text) : [text];
+  const messages: ParsedEmailMessage[] = [];
+  let skippedAttachments = 0;
+  let undecodableParts = 0;
+  let depthExceeded = false;
+  for (const source of sources) {
+    if (source.trim().length === 0) continue;
+    const header = readHeaders(source);
+    const entity = parseEntity(source);
+    if (header === undefined || entity === undefined) {
+      undecodableParts += 1;
+      continue;
+    }
+    const collected = collectBody(entity, 0);
+    skippedAttachments += collected.skippedAttachments;
+    undecodableParts += collected.undecodableParts;
+    depthExceeded ||= collected.depthExceeded;
+    const body = renderMessage(header.headers, collected);
+    if (body === undefined) continue;
+    const value = (name: string): string | undefined => {
+      const raw = header.headers.get(name);
+      return raw === undefined ? undefined : decodeHeaderWords(raw);
+    };
+    messages.push({
+      ...(value("from") === undefined ? {} : { from: value("from")! }),
+      ...(value("to") === undefined ? {} : { to: value("to")! }),
+      ...(value("cc") === undefined ? {} : { cc: value("cc")! }),
+      ...(header.headers.get("date") === undefined ? {} : { date: header.headers.get("date")! }),
+      ...(value("subject") === undefined ? {} : { subject: value("subject")! }),
+      body,
+    });
+  }
+  if (depthExceeded) {
+    throw invalidInput(
+      `The mail source nests more than ${MAXIMUM_NESTING} multipart levels, which cannot be represented as text.`,
+    );
+  }
+  if (messages.length === 0) {
+    throw invalidInput("The mail source did not contain a decodable message.");
+  }
+  return { messages, skippedAttachments, undecodableParts };
+};

--- a/packages/adapters/zzaudit4.test.ts
+++ b/packages/adapters/zzaudit4.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { parseEmailMessages } from "./email-parser.js";
+const bytes = (t: string): Uint8Array => new TextEncoder().encode(t);
+const mb = (sep: string): string =>
+  [
+    sep,
+    "From: A <a@example.com>",
+    "Subject: one",
+    "",
+    "First body.",
+    "",
+    sep.replace(/^From \S+/u, "From b@example.com"),
+    "From: B <b@example.com>",
+    "Subject: two",
+    "",
+    "Second body.",
+    "",
+    sep.replace(/^From \S+/u, "From c@example.com"),
+    "From: C <c@example.com>",
+    "Subject: three",
+    "",
+    "Third body.",
+    "",
+  ].join("\n");
+const html = (inner: string): string =>
+  ["From: h@example.com", "Content-Type: text/html; charset=utf-8", "", inner, ""].join("\r\n");
+
+describe("round-4 audit repros", () => {
+  it("V4-1 trailing-space date-less separators still split", () => {
+    for (const sep of ["From x@y ", "From x@y  ", "From MAILER-DAEMON ", "From - "]) {
+      const parsed = parseEmailMessages(bytes(mb(sep)), true);
+      console.log(`V4-1 ${JSON.stringify(sep)} messages=${parsed.messages.length}`);
+      expect(parsed.messages.length, sep).toBe(3);
+    }
+  });
+  it("V4-2 prose with a digit later in the remainder does not split", () => {
+    const mailbox = [
+      "From a@example.com Fri Sep 11 10:00:00 2026",
+      "From: A <a@example.com>",
+      "Subject: one",
+      "",
+      "Before.",
+      "From the desk of Bob, 2nd floor",
+      "After.",
+      "",
+    ].join("\n");
+    const parsed = parseEmailMessages(bytes(mailbox), true);
+    console.log(
+      `V4-2 messages=${parsed.messages.length} tail=${parsed.messages[0]?.body.includes("After.")}`,
+    );
+    expect(parsed.messages).toHaveLength(1);
+    expect(parsed.messages[0]?.body).toContain("From the desk of Bob, 2nd floor");
+    expect(parsed.messages[0]?.body).toContain("After.");
+  });
+  it("V4-3 a commented-out opener cannot swallow visible text", () => {
+    for (const inner of [
+      "<!-- <script> --><script>LEAK</script>VISIBLE",
+      "<!-- <script> -->VISIBLE<p>TAIL</p><script>LEAK</script>",
+      "<!-- <script> -->A<!-- <script> -->VISIBLE<script>LEAK</script>",
+    ]) {
+      let body = "";
+      try {
+        body = parseEmailMessages(bytes(html(inner)), false).messages[0]?.body ?? "";
+      } catch (e) {
+        body = `THREW: ${(e as Error).message}`;
+      }
+      console.log(
+        `V4-3 in=${JSON.stringify(inner.slice(0, 34))} body=${JSON.stringify(body.slice(-60))}`,
+      );
+      expect(body).toContain("VISIBLE");
+      expect(body).not.toContain("LEAK");
+    }
+  });
+  it("V4-4 tag names are matched at the boundary, not by prefix", () => {
+    for (const inner of [
+      "<scripty>LEAK</scripty>VISIBLE",
+      "<scripts>LEAK</scripts>VISIBLE",
+      "<stylesheet>LEAK</stylesheet>VISIBLE",
+    ]) {
+      const body = parseEmailMessages(bytes(html(inner)), false).messages[0]?.body ?? "";
+      console.log(
+        `V4-4 in=${JSON.stringify(inner.slice(0, 22))} body=${JSON.stringify(body.slice(-40))}`,
+      );
+      expect(body).toContain("LEAK");
+      expect(body).toContain("VISIBLE");
+    }
+  });
+  it("V4-5 unmatched openers keep visible text", () => {
+    const body =
+      parseEmailMessages(bytes(html("<style>LEAK</script>VISIBLE-D")), false).messages[0]?.body ??
+      "";
+    console.log(`V4-5 body=${JSON.stringify(body.slice(-50))}`);
+    expect(body).toContain("VISIBLE-D");
+  });
+});

--- a/packages/cli/src/harvest.test.ts
+++ b/packages/cli/src/harvest.test.ts
@@ -1,0 +1,122 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { describeHarvestSelection, selectHarvestFiles } from "./harvest.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  while (temporaryRoots.length > 0) {
+    const root = temporaryRoots.pop();
+    if (root !== undefined) await rm(root, { recursive: true, force: true });
+  }
+});
+
+const temporaryDirectory = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), "distilly-harvest-"));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = async (root: string, relativePath: string, content = "x\n"): Promise<void> => {
+  const path = join(root, relativePath);
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, content);
+};
+
+describe("directory harvest selection", () => {
+  it("selects supported files in deterministic root-relative order", async () => {
+    const root = await temporaryDirectory();
+    await write(root, "z.txt");
+    await write(root, "nested/a.md");
+    await write(root, "b.eml");
+    await write(root, "nested/deep/c.mbox");
+
+    const selection = await selectHarvestFiles(root);
+
+    expect(selection.files.map((file) => file.relativePath)).toEqual([
+      "b.eml",
+      "nested/a.md",
+      "nested/deep/c.mbox",
+      "z.txt",
+    ]);
+    expect(selection.files.map((file) => file.mediaType)).toEqual([
+      "message/rfc822",
+      "text/markdown",
+      "application/mbox",
+      "text/plain",
+    ]);
+    expect(selection.truncated).toBe(false);
+  });
+
+  it("reports every skipped category instead of treating it as evidence", async () => {
+    const root = await temporaryDirectory();
+    await write(root, ".hidden.txt");
+    await write(root, ".env");
+    await write(root, "keys/server.pem");
+    await write(root, "node_modules/pkg/index.md");
+    await write(root, ".git/config.md");
+    await write(root, "photo.png");
+    await write(root, "keep.txt", "kept\n");
+
+    const selection = await selectHarvestFiles(root);
+
+    expect(selection.files.map((file) => file.pathLabel)).toEqual(["keep.txt"]);
+    expect(selection.skipped).toEqual({
+      credential: 2,
+      "dependency-or-build": 2,
+      hidden: 1,
+      "unsupported-format": 1,
+    });
+  });
+
+  it("never follows a file or directory symlink", async () => {
+    const root = await temporaryDirectory();
+    const outside = await temporaryDirectory();
+    await write(outside, "secret.txt", "outside\n");
+    await write(root, "real.txt", "inside\n");
+    await symlink(join(outside, "secret.txt"), join(root, "linked.txt"));
+    await symlink(outside, join(root, "linked-dir"));
+
+    const selection = await selectHarvestFiles(root);
+
+    expect(selection.files.map((file) => file.pathLabel)).toEqual(["real.txt"]);
+    expect(selection.skipped["symlink"]).toBe(2);
+  });
+
+  it("counts a repeated basename rather than overwriting another file's evidence", async () => {
+    const root = await temporaryDirectory();
+    await write(root, "a/report.md", "first\n");
+    await write(root, "b/report.md", "second\n");
+
+    const selection = await selectHarvestFiles(root);
+
+    expect(selection.files.map((file) => file.relativePath)).toEqual(["a/report.md"]);
+    expect(selection.skipped["duplicate-name"]).toBe(1);
+  });
+
+  it("stops at the selection cap and reports truncation", async () => {
+    const root = await temporaryDirectory();
+    for (let index = 0; index < 5; index += 1) await write(root, `f${String(index)}.txt`);
+
+    const selection = await selectHarvestFiles(root, { maximumFiles: 2 });
+
+    expect(selection.files).toHaveLength(2);
+    expect(selection.truncated).toBe(true);
+  });
+
+  it("renders a stable sorted report", async () => {
+    const root = await temporaryDirectory();
+    await write(root, "keep.txt");
+    await write(root, ".env");
+    await write(root, "photo.png");
+
+    const lines = describeHarvestSelection(await selectHarvestFiles(root));
+
+    expect(lines[0]).toBe("Selected 1 file(s) from 1 director(ies).");
+    expect(lines.slice(1)).toEqual(["  skipped credential: 1", "  skipped unsupported-format: 1"]);
+  });
+});

--- a/packages/cli/src/harvest.ts
+++ b/packages/cli/src/harvest.ts
@@ -1,0 +1,211 @@
+import { lstat, readdir } from "node:fs/promises";
+import { basename, extname, join, relative, sep } from "node:path";
+
+/** Why one discovered path was not selected as evidence. */
+export type HarvestSkipReason =
+  | "credential"
+  | "dependency-or-build"
+  | "duplicate-name"
+  | "hidden"
+  | "not-a-regular-file"
+  | "symlink"
+  | "unsupported-format";
+
+/** One selected regular file, with the label the engine records for it. */
+export interface HarvestFile {
+  readonly path: string;
+  readonly pathLabel: string;
+  readonly mediaType: string;
+  /** Root-relative path with POSIX separators, used for deterministic ordering. */
+  readonly relativePath: string;
+}
+
+/** Complete, deterministic result of selecting evidence from one directory. */
+export interface HarvestSelection {
+  readonly files: readonly HarvestFile[];
+  readonly skipped: Readonly<Partial<Record<HarvestSkipReason, number>>>;
+  readonly directoriesVisited: number;
+  /** True when the selection cap stopped the walk before every entry was considered. */
+  readonly truncated: boolean;
+}
+
+/** Selection limits; a caller may lower them but never silently exceed them. */
+export interface HarvestOptions {
+  readonly maximumFiles?: number;
+}
+
+const DEFAULT_MAXIMUM_FILES = 512;
+
+/** Directory names that hold dependencies, build output, or tool state rather than evidence. */
+const IGNORED_DIRECTORIES = new Set([
+  ".cache",
+  ".git",
+  ".hg",
+  ".svn",
+  ".venv",
+  "__pycache__",
+  "build",
+  "dist",
+  "node_modules",
+  "target",
+  "vendor",
+]);
+
+/** Names that hold secrets rather than material, matched case-insensitively. */
+const CREDENTIAL_NAMES = new Set([
+  ".env",
+  ".netrc",
+  "auth.json",
+  "credentials",
+  "credentials.json",
+  "id_dsa",
+  "id_ed25519",
+  "id_rsa",
+  "secrets.json",
+  "token.json",
+]);
+
+const CREDENTIAL_EXTENSIONS = new Set([".key", ".p12", ".pem", ".pfx"]);
+
+/** Extensions the built-in local parsers accept, mapped to their exact media type. */
+const SUPPORTED_EXTENSIONS = new Map<string, string>([
+  [".eml", "message/rfc822"],
+  [".json", "application/json"],
+  [".markdown", "text/markdown"],
+  [".mbx", "application/mbox"],
+  [".mbox", "application/mbox"],
+  [".md", "text/markdown"],
+  [".srt", "application/x-subrip"],
+  [".txt", "text/plain"],
+  [".vtt", "text/vtt"],
+]);
+
+const compareUtf8 = (left: string, right: string): number => {
+  const encoder = new TextEncoder();
+  const leftBytes = encoder.encode(left);
+  const rightBytes = encoder.encode(right);
+  const length = Math.min(leftBytes.length, rightBytes.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = leftBytes[index]! - rightBytes[index]!;
+    if (difference !== 0) return difference;
+  }
+  return leftBytes.length - rightBytes.length;
+};
+
+const isCredentialName = (name: string): boolean => {
+  const lower = name.toLowerCase();
+  return CREDENTIAL_NAMES.has(lower) || CREDENTIAL_EXTENSIONS.has(extname(lower));
+};
+
+/**
+ * Selects evidence files from one directory the user explicitly named.
+ *
+ * The walk is deterministic (entries sorted by UTF-8 bytes of the root-relative path),
+ * never follows a symlink, and never leaves the selected root. Every discovered path is
+ * either selected or counted under one skip reason, so a caller can report what was left
+ * out instead of silently treating it as evidence.
+ *
+ * @param root - Absolute directory the user selected.
+ * @param options - Optional selection cap.
+ * @returns Selected files plus the skip tally.
+ */
+export const selectHarvestFiles = async (
+  root: string,
+  options: HarvestOptions = {},
+): Promise<HarvestSelection> => {
+  const maximumFiles = options.maximumFiles ?? DEFAULT_MAXIMUM_FILES;
+  const skipped: Partial<Record<HarvestSkipReason, number>> = {};
+  const files: HarvestFile[] = [];
+  const labels = new Set<string>();
+  let directoriesVisited = 0;
+  let truncated = false;
+
+  const skip = (reason: HarvestSkipReason): void => {
+    skipped[reason] = (skipped[reason] ?? 0) + 1;
+  };
+
+  const walk = async (directory: string): Promise<void> => {
+    if (truncated) return;
+    directoriesVisited += 1;
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => compareUtf8(left.name, right.name));
+    for (const entry of entries) {
+      if (truncated) return;
+      const path = join(directory, entry.name);
+      const relativePath = relative(root, path).split(sep).join("/");
+      if (entry.isSymbolicLink()) {
+        // A directory entry for a symlink does not reveal its target, and following it is
+        // exactly what this boundary must not do, so every link is reported as one kind.
+        skip("symlink");
+        continue;
+      }
+      if (entry.isDirectory()) {
+        if (entry.name.startsWith(".") || IGNORED_DIRECTORIES.has(entry.name)) {
+          skip("dependency-or-build");
+          continue;
+        }
+        await walk(path);
+        continue;
+      }
+      // Credentials are checked first so a dotfile such as `.env` is reported as a
+      // credential rather than lumped in with ordinary hidden files.
+      if (isCredentialName(entry.name)) {
+        skip("credential");
+        continue;
+      }
+      if (entry.name.startsWith(".")) {
+        skip("hidden");
+        continue;
+      }
+      const mediaType = SUPPORTED_EXTENSIONS.get(extname(entry.name).toLowerCase());
+      if (mediaType === undefined) {
+        skip("unsupported-format");
+        continue;
+      }
+      const metadata = await lstat(path).catch(() => undefined);
+      if (metadata === undefined || !metadata.isFile() || metadata.isSymbolicLink()) {
+        skip("not-a-regular-file");
+        continue;
+      }
+      const pathLabel = basename(path);
+      if (pathLabel.length === 0 || labels.has(pathLabel)) {
+        // The engine records one label per file and rejects duplicates, so a repeated
+        // basename is reported rather than silently overwriting another file's evidence.
+        skip("duplicate-name");
+        continue;
+      }
+      if (files.length >= maximumFiles) {
+        truncated = true;
+        return;
+      }
+      labels.add(pathLabel);
+      files.push({ path, pathLabel, mediaType, relativePath });
+    }
+  };
+
+  await walk(root);
+  // The walk already emits entries in order, but a directory boundary can interleave a
+  // deeper path before a sibling file, so the final order is fixed explicitly.
+  files.sort((left, right) => compareUtf8(left.relativePath, right.relativePath));
+  return { files, skipped, directoriesVisited, truncated };
+};
+
+/**
+ * Renders a selection report as the exact lines a human reads.
+ *
+ * @param selection - Result of one directory selection.
+ * @returns Stable, sorted report lines.
+ */
+export const describeHarvestSelection = (selection: HarvestSelection): readonly string[] => {
+  const lines = [
+    `Selected ${String(selection.files.length)} file(s) from ${String(selection.directoriesVisited)} director(ies).`,
+  ];
+  const reasons = Object.keys(selection.skipped).sort(compareUtf8) as HarvestSkipReason[];
+  for (const reason of reasons) {
+    lines.push(`  skipped ${reason}: ${String(selection.skipped[reason] ?? 0)}`);
+  }
+  if (selection.truncated) {
+    lines.push("  selection cap reached; remaining entries were not considered.");
+  }
+  return lines;
+};

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -20,6 +20,7 @@ describe("Developer Preview CLI host boundary", () => {
     ["uninstall", ["uninstall", "--host", "other-host"]],
     ["mcp", ["mcp", "--host", "other-host"]],
     ["panel", ["panel", "--host", "other-host"]],
+    ["harvest", ["harvest", "/tmp/evidence", "--host", "other-host", "--name", "Ada"]],
     ["person install", ["install", `subject_${"a".repeat(32)}`, "--host", "other-host"]],
   ])(
     "offers an explicit legacy guide for unsupported %s without switching modes",
@@ -56,6 +57,33 @@ describe("Developer Preview CLI host boundary", () => {
     expect(stderr).toEqual([]);
   });
 
+  it("requires a directory and exactly one subject selector for harvest", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const io = {
+      stdout: { write: (value: string) => stdout.push(value) },
+      stderr: { write: (value: string) => stderr.push(value) },
+    };
+
+    await expect(
+      runPreviewCli(["harvest", "--host", "codex", "--name", "Ada"], environment, io),
+    ).rejects.toThrow("This command requires a directory path, then --host <host>.");
+
+    await expect(
+      runPreviewCli(["harvest", "/tmp/evidence", "--host", "codex"], environment, io),
+    ).rejects.toThrow("Pass exactly one of --subject <subject-id> or --name <display-name>.");
+
+    await expect(
+      runPreviewCli(
+        ["harvest", "/tmp/evidence", "--host", "codex", "--name", "Ada", "--subject", "s"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("Pass exactly one of --subject <subject-id> or --name <display-name>.");
+
+    expect(stdout).toEqual([]);
+  });
+
   it("documents the standalone panel command and the dsh host", async () => {
     const stdout: string[] = [];
     const stderr: string[] = [];
@@ -68,6 +96,7 @@ describe("Developer Preview CLI host boundary", () => {
     ).resolves.toBe(0);
 
     expect(stdout.join("")).toContain("distilly panel --host <host>");
+    expect(stdout.join("")).toContain("distilly harvest <directory>");
     expect(stdout.join("")).toContain("codex | claude-code | openclaw | hermes | dsh");
     expect(stderr).toEqual([]);
   });

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -19,6 +19,7 @@ describe("Developer Preview CLI host boundary", () => {
     ["doctor", ["doctor", "--host", "other-host"]],
     ["uninstall", ["uninstall", "--host", "other-host"]],
     ["mcp", ["mcp", "--host", "other-host"]],
+    ["panel", ["panel", "--host", "other-host"]],
     ["person install", ["install", `subject_${"a".repeat(32)}`, "--host", "other-host"]],
   ])(
     "offers an explicit legacy guide for unsupported %s without switching modes",
@@ -53,5 +54,34 @@ describe("Developer Preview CLI host boundary", () => {
 
     expect(stdout.join("")).toContain("Legacy Skill compatibility path documented in INSTALL.md");
     expect(stderr).toEqual([]);
+  });
+
+  it("documents the standalone panel command and the dsh host", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    await expect(
+      runPreviewCli(["--help"], environment, {
+        stdout: { write: (value) => stdout.push(value) },
+        stderr: { write: (value) => stderr.push(value) },
+      }),
+    ).resolves.toBe(0);
+
+    expect(stdout.join("")).toContain("distilly panel --host <host>");
+    expect(stdout.join("")).toContain("codex | claude-code | openclaw | hermes | dsh");
+    expect(stderr).toEqual([]);
+  });
+
+  it("requires --host for the standalone panel command", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    await expect(
+      runPreviewCli(["panel"], environment, {
+        stdout: { write: (value) => stdout.push(value) },
+        stderr: { write: (value) => stderr.push(value) },
+      }),
+    ).rejects.toThrow("This command requires --host.");
+    expect(stdout).toEqual([]);
   });
 });

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -3,7 +3,7 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { lstat, realpath } from "node:fs/promises";
 
-import { BUILTIN_HOSTS, subjectIdSchema, type HostName } from "@distilly/protocol";
+import { BUILTIN_HOSTS, WIRE_LIMITS, subjectIdSchema, type HostName } from "@distilly/protocol";
 
 import {
   doctorPreview,
@@ -12,6 +12,7 @@ import {
   uninstallPreviewHost,
   type PreviewLifecycleEnvironment,
 } from "./lifecycle.js";
+import { describeHarvestSelection, selectHarvestFiles } from "./harvest.js";
 import {
   PREVIEW_PANEL_ASSETS,
   PREVIEW_PLUGIN_SOURCES,
@@ -154,6 +155,111 @@ export const resolvePreviewCliEnvironment = async (): Promise<PreviewCliEnvironm
   };
 };
 
+/**
+ * Parses the harvest command's arguments into one validated request.
+ *
+ * @param args - Directory path followed by flag pairs.
+ * @returns Directory, host, subject selection, sensitivity, and optional cap.
+ */
+const harvestOptions = (
+  args: readonly string[],
+): {
+  readonly directory: string;
+  readonly host: HostName;
+  readonly subjectId?: string;
+  readonly displayName?: string;
+  readonly sensitivity?: "private" | "shareable";
+  readonly maximumFiles?: number;
+} => {
+  const [directory, ...rest] = args;
+  if (directory === undefined || directory.startsWith("--")) {
+    throw new Error("This command requires a directory path, then --host <host>.");
+  }
+  let host: HostName | undefined;
+  const parsed: {
+    subjectId?: string;
+    displayName?: string;
+    sensitivity?: "private" | "shareable";
+    maximumFiles?: number;
+  } = {};
+  for (let index = 0; index < rest.length; index += 2) {
+    const flag = rest[index];
+    const value = rest[index + 1];
+    if (value === undefined) throw new Error(`Missing value for ${String(flag)}.`);
+    if (flag === "--host") host = parseHost(value);
+    else if (flag === "--subject") parsed.subjectId = value;
+    else if (flag === "--name") parsed.displayName = value;
+    else if (flag === "--sensitivity") {
+      if (value !== "private" && value !== "shareable") {
+        throw new Error("--sensitivity must be private or shareable.");
+      }
+      parsed.sensitivity = value;
+    } else if (flag === "--limit") {
+      const limit = Number.parseInt(value, 10);
+      if (!Number.isSafeInteger(limit) || limit <= 0) throw new Error("--limit must be positive.");
+      parsed.maximumFiles = limit;
+    } else {
+      throw new Error(`Unknown harvest option: ${String(flag)}.`);
+    }
+  }
+  if (host === undefined) throw new Error("This command requires --host.");
+  if ((parsed.subjectId === undefined) === (parsed.displayName === undefined)) {
+    throw new Error("Pass exactly one of --subject <subject-id> or --name <display-name>.");
+  }
+  return { directory, host, ...parsed };
+};
+
+/**
+ * Selects a directory and ingests its evidence in wire-sized batches.
+ *
+ * Batches are capped by the protocol's per-call material limit, so a large export folder
+ * is ingested over several calls with visible progress rather than one oversized request.
+ *
+ * @param args - Directory plus host, subject, sensitivity, and cap options.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ */
+const runHarvest = async (
+  args: readonly string[],
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<void> => {
+  const options = harvestOptions(args);
+  const selection = await selectHarvestFiles(options.directory, {
+    ...(options.maximumFiles === undefined ? {} : { maximumFiles: options.maximumFiles }),
+  });
+  for (const line of describeHarvestSelection(selection)) io.stdout.write(`${line}\n`);
+  if (selection.files.length === 0) {
+    io.stdout.write("Nothing to ingest.\n");
+    return;
+  }
+  const application = await openApplication(options.host, environment);
+  try {
+    const batchSize = WIRE_LIMITS.ingestMaterials;
+    let subjectId: string | undefined = options.subjectId;
+    let ingested = 0;
+    for (let start = 0; start < selection.files.length; start += batchSize) {
+      const batch = selection.files.slice(start, start + batchSize);
+      const result = await application.distilly.ingestFiles({
+        subject:
+          subjectId === undefined
+            ? { kind: "create", input: { displayName: options.displayName ?? "" } }
+            : { kind: "existing", subjectId: subjectIdSchema.parse(subjectId) },
+        paths: batch.map((file) => file.path),
+        enqueue: "auto",
+        ...(options.sensitivity === undefined ? {} : { sensitivity: options.sensitivity }),
+      });
+      subjectId = result.subject.id;
+      ingested += batch.length;
+      io.stdout.write(
+        `Ingested ${String(ingested)}/${String(selection.files.length)} file(s) as ${result.subject.displayName} (${result.subject.id}).\n`,
+      );
+    }
+  } finally {
+    await application.close();
+  }
+};
+
 const help = `Distilly Developer Preview
 
 Usage:
@@ -163,6 +269,8 @@ Usage:
   distilly install <subject-id> --host <host>
   distilly uninstall --host <host>
   distilly panel --host <host>
+  distilly harvest <directory> --host <host> --subject <subject-id>|--name <display-name>
+                   [--sensitivity private|shareable] [--limit <n>]
   # <host>: codex | claude-code | openclaw | hermes | dsh
 
 The host bindings share the same five-tool MCP contract. Setup remains
@@ -231,6 +339,10 @@ export const runPreviewCli = async (
     const host = hostOption(args, true);
     if (host === undefined) throw new Error("This command requires --host.");
     await runMcp(host, environment);
+    return 0;
+  }
+  if (command === "harvest") {
+    await runHarvest(args, environment, io);
     return 0;
   }
   if (command === "panel") {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -69,6 +69,46 @@ const openApplication = async (host: HostName, environment: PreviewCliEnvironmen
   });
 };
 
+/**
+ * Resolves when the operator interrupts the process or closes standard input.
+ *
+ * @returns A promise that settles on the first shutdown signal.
+ */
+const waitForShutdown = async (): Promise<void> => {
+  await new Promise<void>((resolvePromise) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      process.off("SIGINT", finish);
+      process.off("SIGTERM", finish);
+      process.stdin.off("end", finish);
+      resolvePromise();
+    };
+    process.once("SIGINT", finish);
+    process.once("SIGTERM", finish);
+    // A closed stdin means the operator or a supervisor stopped waiting for the panel.
+    process.stdin.once("end", finish);
+  });
+};
+
+const runPanel = async (
+  host: HostName,
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<void> => {
+  const application = await openApplication(host, environment);
+  try {
+    const url = await application.startPanel();
+    io.stdout.write(
+      `Distilly review panel for ${host}: ${url}\nReview local profiles in a browser; press Ctrl-C to stop.\n`,
+    );
+    await waitForShutdown();
+  } finally {
+    await application.close();
+  }
+};
+
 const runMcp = async (host: HostName, environment: PreviewCliEnvironment): Promise<void> => {
   const application = await openApplication(host, environment);
   try {
@@ -122,9 +162,10 @@ Usage:
   distilly doctor [--host <host>]
   distilly install <subject-id> --host <host>
   distilly uninstall --host <host>
-  # <host>: codex | claude-code | openclaw | hermes
+  distilly panel --host <host>
+  # <host>: codex | claude-code | openclaw | hermes | dsh
 
-The four host bindings share the same five-tool MCP contract. Setup remains
+The host bindings share the same five-tool MCP contract. Setup remains
 fail-closed until this release has an exact verified capacity fixture for the
 selected host version; no synthetic capacity is used. Other hosts:
   Use the explicit Legacy Skill compatibility path documented in INSTALL.md.
@@ -190,6 +231,12 @@ export const runPreviewCli = async (
     const host = hostOption(args, true);
     if (host === undefined) throw new Error("This command requires --host.");
     await runMcp(host, environment);
+    return 0;
+  }
+  if (command === "panel") {
+    const host = hostOption(args, true);
+    if (host === undefined) throw new Error("This command requires --host.");
+    await runPanel(host, environment, io);
     return 0;
   }
   io.stderr.write(`Unknown or unavailable Developer Preview command: ${command}.\n`);

--- a/packages/cli/src/preview.ts
+++ b/packages/cli/src/preview.ts
@@ -37,6 +37,16 @@ export interface PreviewMcpApplication {
   /** Serves the exact five MCP tools on this process's stdio transport. */
   runStdio(): Promise<void>;
 
+  /**
+   * Starts the loopback review Panel and returns the URL a human opens.
+   *
+   * A review presentation normally starts the Panel on demand; the standalone panel
+   * command needs the root URL without a suspended candidate.
+   *
+   * @returns The validated loopback root URL, including its access token.
+   */
+  startPanel(): Promise<string>;
+
   /** Closes presenters and clients before releasing the single-writer runtime. */
   close(): Promise<void>;
 }
@@ -87,6 +97,13 @@ class PreviewMcpApplicationImplementation implements PreviewMcpApplication {
     }
     this.#stdioPromise ??= runStdio(this.#mcp);
     return this.#stdioPromise;
+  }
+
+  startPanel(): Promise<string> {
+    if (this.#closePromise !== undefined) {
+      return Promise.reject(new Error("The Developer Preview MCP application is closing."));
+    }
+    return this.#panel.start();
   }
 
   close(): Promise<void> {

--- a/packages/distilly/src/distilly.ts
+++ b/packages/distilly/src/distilly.ts
@@ -5,6 +5,8 @@ import type {
   CreateSubjectInput,
   EngineClient,
   HostDistillBriefing,
+  IngestFilesInput,
+  IngestFilesResult,
   JobLease,
   PendingFilter,
   PendingJob,
@@ -74,6 +76,28 @@ export class Distilly {
       mutationContext(mutation?.requestId),
     );
     return this.person(subject.id);
+  }
+
+  /**
+   * Ingests explicitly selected local files as material for one subject.
+   *
+   * The caller owns file selection; this method only forwards the exact paths, so a
+   * direct-user surface such as the harvest command can batch a large selection without
+   * widening any model-facing tool.
+   *
+   * @param input - Subject target, explicit local paths, enqueue policy, and sensitivity.
+   * @param mutation - Optional request identity for replay.
+   * @returns Per-file ingest results plus the resulting generation and pending job.
+   */
+  async ingestFiles(
+    input: IngestFilesInput,
+    mutation?: MutationOptions,
+  ): Promise<IngestFilesResult> {
+    return await this.#client.call(
+      "materials.ingestFiles",
+      input,
+      mutationContext(mutation?.requestId),
+    );
   }
 
   /**

--- a/packages/panel/src/server-launcher.ts
+++ b/packages/panel/src/server-launcher.ts
@@ -99,6 +99,26 @@ export class PanelLauncher implements ReviewPresenter {
   }
 
   /**
+   * Starts the one owned Panel and returns its browser entry URL.
+   *
+   * The standalone `distilly panel` command uses this to report the URL a human should
+   * open; a review presentation keeps using {@link present}, which appends the exact
+   * review route to this same root.
+   *
+   * @returns The validated loopback root URL, including its access token.
+   */
+  async start(): Promise<string> {
+    if (this.#state === "closing" || this.#state === "closed") {
+      throw new Error("PanelLauncher is closing or closed.");
+    }
+    const handle = await this.#start();
+    if (this.#state !== "running" || this.#handle !== handle) {
+      throw new Error("PanelLauncher closed while the Panel was starting.");
+    }
+    return handle.url;
+  }
+
+  /**
    * Presents exactly one immutable suspended-candidate reference.
    *
    * @param review - Candidate selected by the engine.

--- a/packages/runtime/src/preview.ts
+++ b/packages/runtime/src/preview.ts
@@ -94,6 +94,11 @@ const mediaTypeForPath = (path: string): string => {
       return "text/markdown";
     case ".json":
       return "application/json";
+    case ".eml":
+      return "message/rfc822";
+    case ".mbox":
+    case ".mbx":
+      return "application/mbox";
     case ".srt":
       return "application/x-subrip";
     case ".vtt":


### PR DESCRIPTION
## What
feat: local evidence intake (EML/MBOX parser, panel command, directory harvest)

## Commits
- feat(adapters): parse EML and MBOX mail material
- feat(cli): add a standalone distilly panel command
- fix(adapters): close the round-four mail parser findings
- feat(cli): harvest a selected directory into material
- fix(adapters): close the round-five mail parser findings

## Stack
Stacked on `pr/01-dsh-binding`; the whole series ends at `distilly-work` (`0bd924e`).

## Verification
Every feature carries an author report and an independent audit in the delivery evidence folder (`host-verification/`), including screenshots and the audit verdict that drove the fixes. Gates on the top of the stack: format, lint, docs, release check, and 1163 tests.

## Real hosts
Codex, Claude Code 2.1.268, OpenClaw 2026.9.2, Hermes v0.19.0, and DSH 0.1.5-rc.1 were each exercised end to end (install, host-visible confirmation, exactly five MCP tools, person Skill install/remove, uninstall). Capacity fixtures are recorded for Codex 0.146.0, OpenClaw 2026.3.24, and Hermes v0.9.0; newer host versions run on the labelled conservative floor.

## Evidence
Author reports and screenshots (delivery evidence folder `host-verification/`):
- f1-email-parser-REPORT.md
- f6-panel-command-REPORT.md
- f2-harvest-REPORT.md
- panel-standalone.png, panel-standalone-run.txt, harvest-run.txt

Independent audit reports:
- email-parser-AUDIT-independent.md, email-parser-REAUDIT.md, email-parser-VERIFY3/4/5.md