### PR TITLE
fix(adapters): discriminate mbox separators deterministically

### DIFF
--- a/packages/adapters/src/builtin-parsers.ts
+++ b/packages/adapters/src/builtin-parsers.ts
@@ -115,6 +115,11 @@ const emailParser = (id: string, mediaType: string, mbox: boolean): MaterialPars
       if (parsed.undecodableParts > 0) {
         warnings.push(`${parsed.undecodableParts} part(s) could not be decoded as text.`);
       }
+      if (parsed.unrecognizedSeparatorLines > 0) {
+        warnings.push(
+          `${parsed.unrecognizedSeparatorLines} line(s) begin with "From " without being a recognized mbox separator; later messages may be merged.`,
+        );
+      }
       const result = draft(
         input,
         rendered,

--- a/packages/adapters/src/email-parser.test.ts
+++ b/packages/adapters/src/email-parser.test.ts
@@ -601,37 +601,83 @@ describe("mail material parsing", () => {
       expect(Date.now() - started).toBeLessThan(3_000);
     });
 
-    it("splits every date shape real writers emit", () => {
-      for (const separator of [
+    it("splits every documented separator shape in a middle position", () => {
+      // The tested separator is deliberately placed between two messages: a separator in
+      // the first line would split because splitMailbox always starts a message there, so
+      // a first-position test would confirm any nonsense rule, including "From x@y zzz".
+      const shapes = [
         "From x@y\t",
         "From x@y\t ",
+        "From x@y ",
         "From x@y  Fri Sep 11 02:31:00 2026",
         "From x@y  2026-09-11 02:31:00",
         "From x@y Friday, 11 Sep 2026 02:31:00 +0000",
         "From x@y 11-Sep-2026 02:31:00",
         "From x@y 11/09/2026 02:31:00",
+        "From x@y 2026/09/11 02:31:00",
+        "From x@y fri sep 11 02:31:00 2026",
         "From x@y 02:31:00 2026",
         "From x@y 20260911",
         "From x@y 1789000000",
         "From x@y <1789000000>",
-      ]) {
+        "From MAILER-DAEMON Sat Sep 11 02:31:00 2026",
+        "From - Fri Sep 11 02:31:00 2026",
+      ];
+      for (const shape of shapes) {
         const mailbox = [
-          separator,
+          "From a@example.com Fri Sep 11 10:00:00 2026",
           "From: A <a@example.com>",
           "Subject: one",
           "",
           "First body.",
           "",
-          "From b@example.com Fri Sep 11 10:00:00 2026",
+          shape,
           "From: B <b@example.com>",
           "Subject: two",
           "",
           "Second body.",
           "",
+          "From c@example.com Fri Sep 11 12:00:00 2026",
+          "From: C <c@example.com>",
+          "Subject: three",
+          "",
+          "Third body.",
+          "",
         ].join("\n");
         const parsed = parseEmailMessages(bytes(mailbox), true);
-        expect(parsed.messages.length, separator).toBe(2);
-        expect(parsed.messages[1]?.subject, separator).toBe("two");
+        expect(
+          parsed.messages.map((message) => message.subject),
+          shape,
+        ).toEqual(["one", "two", "three"]);
+      }
+    });
+
+    it("never splits prose or a quoted address in a middle position", () => {
+      for (const line of [
+        "From now on the plan changes.",
+        "From the desk of Bob, 2nd floor",
+        "From alice@example.com wrote:",
+        "From 2026 we will change everything.",
+        "From 09:30 until 17:00 we are closed.",
+        "From the 11/09/2026 invoice is attached.",
+        "From the 12345678 records are attached.",
+        "From the 20260911 backup was restored.",
+        "From x@y zzz nonsense",
+      ]) {
+        const mailbox = [
+          "From a@example.com Fri Sep 11 10:00:00 2026",
+          "From: A <a@example.com>",
+          "Subject: one",
+          "",
+          "Before.",
+          line,
+          "After.",
+          "",
+        ].join("\n");
+        const parsed = parseEmailMessages(bytes(mailbox), true);
+        expect(parsed.messages, line).toHaveLength(1);
+        expect(parsed.messages[0]?.body, line).toContain(line);
+        expect(parsed.messages[0]?.body, line).toContain("After.");
       }
     });
 

--- a/packages/adapters/src/email-parser.test.ts
+++ b/packages/adapters/src/email-parser.test.ts
@@ -652,6 +652,74 @@ describe("mail material parsing", () => {
       }
     });
 
+    it("splits every real sender shape, including bare usernames and hostnames", () => {
+      // Round 7 measured these as regressions when the separator rule gated on the sender
+      // token: a bare local username is a real sender, so the token cannot discriminate.
+      for (const shape of [
+        "From ada Fri Sep 11 10:00:00 2026",
+        "From alice Fri Sep 11 10:00:00 2026",
+        "From ada, Fri Sep 11 10:00:00 2026",
+        "From ada@localhost Fri Sep 11 10:00:00 2026",
+        "From localhost Fri Sep 11 10:00:00 2026",
+        "From example.com Fri Sep 11 10:00:00 2026",
+        "From ada 2026-09-11T10:00:00Z",
+        "From ada 11/09/2026 10:00:00",
+        "From ada 20260911",
+        "From ada 1789000000",
+        "From ada",
+        "From x@y 11-Sep-2026 02:31:00",
+      ]) {
+        const mailbox = [
+          "From a@example.com Fri Sep 11 10:00:00 2026",
+          "From: A <a@example.com>",
+          "Subject: one",
+          "",
+          "First body.",
+          "",
+          shape,
+          "From: B <b@example.com>",
+          "Subject: two",
+          "",
+          "Second body.",
+          "",
+          "From c@example.com Fri Sep 11 12:00:00 2026",
+          "From: C <c@example.com>",
+          "Subject: three",
+          "",
+          "Third body.",
+          "",
+        ].join("\n");
+        expect(
+          parseEmailMessages(bytes(mailbox), true).messages.map((message) => message.subject),
+          shape,
+        ).toEqual(["one", "two", "three"]);
+      }
+    });
+
+    it("rejects prose that starts with a number, a month, or a time", () => {
+      for (const line of [
+        "From alice@example.com 09:30 works for me.",
+        "From Sep we will change everything.",
+        "From 11/09/2026 invoice is attached.",
+        "From 20260911 backup was restored.",
+      ]) {
+        const mailbox = [
+          "From a@example.com Fri Sep 11 10:00:00 2026",
+          "From: A <a@example.com>",
+          "Subject: one",
+          "",
+          "Before.",
+          line,
+          "After.",
+          "",
+        ].join("\n");
+        const parsed = parseEmailMessages(bytes(mailbox), true);
+        expect(parsed.messages, line).toHaveLength(1);
+        expect(parsed.messages[0]?.body, line).toContain(line);
+        expect(parsed.messages[0]?.body, line).toContain("After.");
+      }
+    });
+
     it("never splits prose or a quoted address in a middle position", () => {
       for (const line of [
         "From now on the plan changes.",

--- a/packages/adapters/src/email-parser.ts
+++ b/packages/adapters/src/email-parser.ts
@@ -61,38 +61,30 @@ const MBOX_SEPARATOR = /^From (\S+)(?:[ \t]+(.*))?$/u;
  *
  * Writers emit ctime (`Fri Sep  1 10:00:00 2026`), day-month (`11 Sep 2026`), hyphenated
  * or slashed dates, ISO 8601, a compact date, a leading time, or epoch seconds, sometimes
- * after a padded sender. The shape must begin where the remainder begins, so prose that
- * merely contains a digit later (`From the desk of Bob, 2nd floor`) and a bare year
- * (`From 2026 we will change everything.`) stay body text.
+ * after a padded sender. The date must be complete: a month-name date always carries a day
+ * and a time, and a numeric date either carries a time or ends the line. That keeps every
+ * real writer's format while rejecting prose that merely starts with a number, such as
+ * `From the 11/09/2026 invoice is attached.` or `From 09:30 until 17:00 we are closed.`.
  */
-const MBOX_DATE =
-  /^[ \t]*(?:[A-Za-z]{3,},?[ \t]+)?(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[ \t]+\d{1,2}|\d{1,2}[- ][A-Za-z]{3,}[- ]\d{2,4}|\d{1,2}[-/]\d{1,2}[-/]\d{2,4}|\d{4}[-/]\d{2}[-/]\d{2}|\d{4}-\d{2}-\d{2}|\d{8}|\d{1,2}:\d{2}|\d{9,}|<\d+>)/iu;
-
-/**
- * Sender tokens that identify an mbox `from_` line without an address.
- *
- * A `from_` line names the envelope sender, so it carries an address or one of the
- * well-known system names. Requiring that is what keeps prose out: an ordinary word or a
- * time-like number after "From " never matches, while every real separator does.
- */
-const MBOX_SYSTEM_SENDERS = new Set([
-  "-",
-  "daemon",
-  "mailer-daemon",
-  "nobody",
-  "postmaster",
-  "root",
-  "www-data",
-]);
-
-/**
- * Reports whether a sender token could open a real `from_` line.
- *
- * @param token - Token between "From " and the rest of the line.
- * @returns True when the token is an address or a known system sender.
- */
-const isSenderToken = (token: string): boolean =>
-  token.includes("@") || MBOX_SYSTEM_SENDERS.has(token.toLowerCase());
+const MBOX_MONTH = "Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec";
+const MBOX_DATE = new RegExp(
+  "^(?:[ \\t]*)" +
+    // An optional weekday applies to every branch, so both `Fri Sep 11 02:31` and the
+    // RFC 2822 `Friday, 11 Sep 2026 02:31:00 +0000` form are recognized.
+    "(?:[A-Za-z]{3,},?[ \\t]+)?" +
+    "(?:" +
+    `(?:${MBOX_MONTH})[ \\t]+\\d{1,2}[ \\t]+\\d{1,2}:\\d{2}` +
+    `|\\d{1,2}[ \\t]+(?:${MBOX_MONTH})[ \\t]+\\d{2,4}` +
+    "|\\d{1,2}[-](?:[A-Za-z]{3,})[-]\\d{2,4}(?:[ \\t]+\\d{1,2}:\\d{2}(?::\\d{2})?)?" +
+    "|\\d{1,2}[-/]\\d{1,2}[-/]\\d{2,4}(?:[ \\t]+\\d{1,2}:\\d{2}(?::\\d{2})?(?:[ \\t]+\\S+)*)?[ \\t]*$" +
+    "|\\d{8}(?:[ \\t]*$|[ \\t]+\\d{1,2}:\\d{2})" +
+    "|\\d{4}[-/]\\d{2}[-/]\\d{2}(?:[T \\t]\\d{1,2}:\\d{2}(?::\\d{2})?(?:Z|[+-]\\d{2}:?\\d{2})?)?" +
+    "|\\d{1,2}:\\d{2}(?::\\d{2})?[ \\t]+\\d{2,4}" +
+    "|\\d{9,}[ \\t]*$" +
+    "|<\\d+>[ \\t]*$" +
+    ")",
+  "iu",
+);
 
 /**
  * Maps bytes to a code-point-preserving string so structural scanning never confuses a
@@ -670,15 +662,12 @@ const splitMailbox = (
   for (const line of text.split(/\r\n|\r|\n/u)) {
     const isFirst = !sawSeparator && current === undefined;
     const separator = MBOX_SEPARATOR.exec(line);
-    // The sender token discriminates: a `from_` line names an address or a system sender,
-    // while prose starts with an ordinary word ("From the desk of…", "From now on…") or a
-    // time-like number ("From 09:30 until…"). Only then must the remainder be empty or
-    // start with a date, which rejects a quoted address such as "From alice@… wrote:".
-    // Without the token gate, accepting every real date shape admitted exactly that prose.
+    // A separator has an empty remainder, or one that starts with a complete date. The
+    // sender token deliberately does not participate: a bare local username or a hostname
+    // is a real sender, and gating on the token merged exactly those mailboxes.
     const remainder = separator?.[2];
     const isSeparator =
       separator !== null &&
-      isSenderToken(separator[1]!) &&
       (remainder === undefined || remainder.trim() === "" || MBOX_DATE.test(remainder));
     if (line.startsWith("From ") && (isFirst || isSeparator)) {
       if (current !== undefined) messages.push(current.join("\n"));

--- a/packages/adapters/src/email-parser.ts
+++ b/packages/adapters/src/email-parser.ts
@@ -15,6 +15,13 @@ export interface ParsedEmail {
   readonly messages: readonly ParsedEmailMessage[];
   readonly skippedAttachments: number;
   readonly undecodableParts: number;
+  /**
+   * Body lines that begin with "From " without being a recognized separator.
+   *
+   * The mbox format escapes those lines; a writer that did not leaves the split
+   * ambiguous, so the count is reported rather than resolved silently.
+   */
+  readonly unrecognizedSeparatorLines: number;
 }
 
 /** Maximum multipart nesting depth before the source is rejected as unrepresentable. */
@@ -59,7 +66,33 @@ const MBOX_SEPARATOR = /^From (\S+)(?:[ \t]+(.*))?$/u;
  * (`From 2026 we will change everything.`) stay body text.
  */
 const MBOX_DATE =
-  /^[ \t]*(?:[A-Za-z]{3,},?[ \t]+)?(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[ \t]+\d{1,2}|\d{1,2}[ \t]+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)|\d{1,2}[-/]\d{1,2}[-/]\d{2,4}|\d{4}-\d{2}-\d{2}|\d{8}|\d{1,2}:\d{2}|\d{9,}|<\d+>)/u;
+  /^[ \t]*(?:[A-Za-z]{3,},?[ \t]+)?(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[ \t]+\d{1,2}|\d{1,2}[- ][A-Za-z]{3,}[- ]\d{2,4}|\d{1,2}[-/]\d{1,2}[-/]\d{2,4}|\d{4}[-/]\d{2}[-/]\d{2}|\d{4}-\d{2}-\d{2}|\d{8}|\d{1,2}:\d{2}|\d{9,}|<\d+>)/iu;
+
+/**
+ * Sender tokens that identify an mbox `from_` line without an address.
+ *
+ * A `from_` line names the envelope sender, so it carries an address or one of the
+ * well-known system names. Requiring that is what keeps prose out: an ordinary word or a
+ * time-like number after "From " never matches, while every real separator does.
+ */
+const MBOX_SYSTEM_SENDERS = new Set([
+  "-",
+  "daemon",
+  "mailer-daemon",
+  "nobody",
+  "postmaster",
+  "root",
+  "www-data",
+]);
+
+/**
+ * Reports whether a sender token could open a real `from_` line.
+ *
+ * @param token - Token between "From " and the rest of the line.
+ * @returns True when the token is an address or a known system sender.
+ */
+const isSenderToken = (token: string): boolean =>
+  token.includes("@") || MBOX_SYSTEM_SENDERS.has(token.toLowerCase());
 
 /**
  * Maps bytes to a code-point-preserving string so structural scanning never confuses a
@@ -627,19 +660,25 @@ const renderMessage = (
   return lines.join("\n");
 };
 
-const splitMailbox = (text: string): readonly string[] => {
+const splitMailbox = (
+  text: string,
+): { readonly messages: readonly string[]; readonly unrecognized: number } => {
   const messages: string[] = [];
+  let unrecognizedFromLines = 0;
   let current: string[] | undefined;
   let sawSeparator = false;
   for (const line of text.split(/\r\n|\r|\n/u)) {
     const isFirst = !sawSeparator && current === undefined;
     const separator = MBOX_SEPARATOR.exec(line);
-    // A separator has either no remainder or a remainder that starts with a date, so every
-    // writer's date format separates while prose ("From now on ...", "From the desk of
-    // Bob, 2nd floor") and a quoted address ("From alice@example.com wrote:") stay text.
+    // The sender token discriminates: a `from_` line names an address or a system sender,
+    // while prose starts with an ordinary word ("From the desk of…", "From now on…") or a
+    // time-like number ("From 09:30 until…"). Only then must the remainder be empty or
+    // start with a date, which rejects a quoted address such as "From alice@… wrote:".
+    // Without the token gate, accepting every real date shape admitted exactly that prose.
     const remainder = separator?.[2];
     const isSeparator =
       separator !== null &&
+      isSenderToken(separator[1]!) &&
       (remainder === undefined || remainder.trim() === "" || MBOX_DATE.test(remainder));
     if (line.startsWith("From ") && (isFirst || isSeparator)) {
       if (current !== undefined) messages.push(current.join("\n"));
@@ -647,10 +686,15 @@ const splitMailbox = (text: string): readonly string[] => {
       sawSeparator = true;
       continue;
     }
+    if (line.startsWith("From ") && !isSeparator) {
+      // An unescaped body line that merely looks like a separator is the format's own
+      // ambiguity, so the count is reported instead of being decided silently.
+      unrecognizedFromLines += 1;
+    }
     current?.push(line);
   }
   if (current !== undefined) messages.push(current.join("\n"));
-  return messages;
+  return { messages, unrecognized: unrecognizedFromLines };
 };
 
 /**
@@ -665,7 +709,8 @@ const splitMailbox = (text: string): readonly string[] => {
  */
 export const parseEmailMessages = (bytes: Uint8Array, mbox: boolean): ParsedEmail => {
   const text = bytesToBinaryString(bytes);
-  const sources = mbox ? splitMailbox(text) : [text];
+  const split = mbox ? splitMailbox(text) : { messages: [text], unrecognized: 0 };
+  const sources = split.messages;
   const messages: ParsedEmailMessage[] = [];
   let skippedAttachments = 0;
   let undecodableParts = 0;
@@ -705,5 +750,10 @@ export const parseEmailMessages = (bytes: Uint8Array, mbox: boolean): ParsedEmai
   if (messages.length === 0) {
     throw invalidInput("The mail source did not contain a decodable message.");
   }
-  return { messages, skippedAttachments, undecodableParts };
+  return {
+    messages,
+    skippedAttachments,
+    undecodableParts,
+    unrecognizedSeparatorLines: split.unrecognized,
+  };
 };


### PR DESCRIPTION
## What
fix(adapters): discriminate mbox separators deterministically

## Commits
- fix(adapters): gate mbox separators on the sender token
- fix(adapters): discriminate mbox separators by a complete date, not the sender token

## Stack
Stacked on `pr/03-capacity-honesty`; the whole series ends at `distilly-work` (`0bd924e`).

## Verification
Every feature carries an author report and an independent audit in the delivery evidence folder (`host-verification/`), including screenshots and the audit verdict that drove the fixes. Gates on the top of the stack: format, lint, docs, release check, and 1163 tests.

## Real hosts
Codex, Claude Code 2.1.268, OpenClaw 2026.9.2, Hermes v0.19.0, and DSH 0.1.5-rc.1 were each exercised end to end (install, host-visible confirmation, exactly five MCP tools, person Skill install/remove, uninstall). Capacity fixtures are recorded for Codex 0.146.0, OpenClaw 2026.3.24, and Hermes v0.9.0; newer host versions run on the labelled conservative floor.

## Evidence
Author reports and screenshots (delivery evidence folder `host-verification/`):
- (covered by the email parser reports above)

Independent audit reports:
- email-parser-VERIFY5.md, email-parser-VERIFY6.md, email-parser-VERIFY7.md