### PR TITLE
feat(cli): Hermes lifecycle on a real host; runtime splits oversized files

### DIFF
--- a/packages/bindings/src/compatibility-binding.test.ts
+++ b/packages/bindings/src/compatibility-binding.test.ts
@@ -450,7 +450,7 @@ describe("Hermes compatibility binding", () => {
     const wrapper = join(home, ".distilly", "bin", "distilly-hermes");
     const run = vi.fn<HostCommandRunner["run"]>(async ({ args }) => {
       const command = args.join(" ");
-      if (command === "mcp add distilly --command " + wrapper) {
+      if (command === "mcp add distilly --command " + wrapper + " --connect-timeout 20") {
         await writeFile(
           configPath,
           `mcp_servers:\n  distilly:\n    command: ${hermesCommandScalar(wrapper)}\n    enabled: true\n    tools:\n      resources: true\n      prompts: true\n`,
@@ -516,7 +516,7 @@ describe("Hermes compatibility binding", () => {
     const run: HostCommandRunner = {
       run: async ({ args }) => {
         const command = args.join(" ");
-        if (command === "mcp add distilly --command " + wrapper) {
+        if (command === "mcp add distilly --command " + wrapper + " --connect-timeout 20") {
           await writeFile(
             configPath,
             `mcp_servers:\n  distilly:\n    command: ${wrapper}\n    enabled: true\n    tools:\n      resources: true\n      prompts: true\n`,
@@ -553,7 +553,7 @@ describe("Hermes compatibility binding", () => {
     const run: HostCommandRunner = {
       run: async ({ args }) => {
         const command = args.join(" ");
-        if (command === "mcp add distilly --command " + wrapper) {
+        if (command === "mcp add distilly --command " + wrapper + " --connect-timeout 20") {
           await writeFile(
             configPath,
             `mcp_servers:\n  distilly:\n    command: ${hermesCommandScalar(wrapper)}\n    enabled: true\n    tools:\n      resources: true\n      prompts: true\n`,
@@ -601,7 +601,7 @@ describe("Hermes compatibility binding", () => {
     const run: HostCommandRunner = {
       run: async ({ args }) => {
         const command = args.join(" ");
-        if (command === "mcp add distilly --command " + wrapper) {
+        if (command === "mcp add distilly --command " + wrapper + " --connect-timeout 20") {
           await writeFile(
             configPath,
             `mcp_servers:\n  distilly:\n    command: ${hermesCommandScalar(wrapper)}\n    enabled: true\n    tools:\n      resources: true\n      prompts: true\n`,
@@ -648,7 +648,7 @@ describe("Hermes compatibility binding", () => {
     const run: HostCommandRunner = {
       run: async ({ args }) => {
         const command = args.join(" ");
-        if (command === "mcp add distilly --command " + wrapper) {
+        if (command === "mcp add distilly --command " + wrapper + " --connect-timeout 20") {
           await writeFile(
             configPath,
             `mcp_servers:\n  distilly:\n    command: ${hermesCommandScalar(wrapper)}\n    enabled: true\n    tools:\n      resources: true\n      prompts: true\n`,
@@ -703,7 +703,7 @@ describe("Hermes compatibility binding", () => {
     const run: HostCommandRunner = {
       run: async ({ args }) => {
         const command = args.join(" ");
-        if (command === "mcp add distilly --command " + wrapper) {
+        if (command === "mcp add distilly --command " + wrapper + " --connect-timeout 20") {
           config = true;
           await writeFile(
             configPath,

--- a/packages/bindings/src/compatibility-binding.test.ts
+++ b/packages/bindings/src/compatibility-binding.test.ts
@@ -508,6 +508,71 @@ describe("Hermes compatibility binding", () => {
     await expect(readFile(configPath, "utf8")).resolves.toBe("mcp_servers:\n");
   });
 
+  it("repairs its own interrupted Hermes entry instead of dead-ending", async () => {
+    // An interrupted setup leaves the host having written the entry with our wrapper but
+    // without the tool toggles. The second run must converge by re-applying them, because
+    // refusing left both setup and uninstall with no recovery but manual host surgery.
+    const parent = await temporaryHome();
+    const home = join(parent, "home");
+    await mkdir(home, { recursive: true });
+    const launcherPath = await launcher(home);
+    const wrapper = join(home, ".distilly", "bin", "distilly-hermes");
+    const configPath = join(home, ".hermes", "config.yaml");
+    const entry = (tools: boolean, enabled: boolean): string =>
+      `_config_version: 33\nmcp_servers:\n  distilly:\n    command: ${hermesCommandScalar(wrapper)}\n    enabled: ${enabled ? "true" : "false"}\n${
+        tools ? "    tools:\n      resources: false\n      prompts: false\n" : ""
+      }`;
+    const run: HostCommandRunner = {
+      run: async ({ args }) => {
+        const command = args.join(" ");
+        if (command === "mcp add distilly --command " + wrapper + " --connect-timeout 20") {
+          await writeFile(configPath, entry(false, true), { mode: 0o600 });
+        } else if (command.startsWith("config set")) {
+          const content = await readFile(configPath, "utf8");
+          const key = command.split(" ").at(-2)!;
+          const value = command.split(" ").at(-1)!;
+          if (key.endsWith("enabled")) {
+            await writeFile(
+              configPath,
+              content.replace(/enabled: (true|false)/u, `enabled: ${value}`),
+            );
+          } else {
+            await writeFile(
+              configPath,
+              content.includes("tools:")
+                ? content
+                : `${content}    tools:\n      resources: false\n      prompts: false\n`,
+            );
+          }
+        }
+        return command === "mcp test distilly" ? success("Tools discovered: 5") : success();
+      },
+    };
+    const binding = createHermesHostBinding(options("hermes", home, run));
+    const context = {
+      launcherPath,
+      pluginSourcePath: join(REPOSITORY_ROOT, "plugins", "shared", "skills", "distilly"),
+      runtimeVersion: releaseVersion,
+    };
+    // First run installs the Skill and a complete entry.
+    await binding.installPlugin(context);
+    // Simulate the interrupted state a killed setup leaves on disk: the entry still names
+    // our wrapper and the Skill is ours, but the tool toggles never landed.
+    await writeFile(configPath, entry(false, false), { mode: 0o600 });
+
+    // A second run must repair that entry rather than refuse it.
+    const repaired = await binding.installPlugin(context);
+    expect(repaired.host).toBe("hermes");
+    const content = await readFile(configPath, "utf8");
+    expect(content).toContain("enabled: true");
+    expect(content).toContain("resources: false");
+    expect(content).toContain("prompts: false");
+    expect(await binding.doctor({ sessionId: "hermes-repair", environment: "cli" })).toMatchObject({
+      installed: true,
+      warnings: [],
+    });
+  });
+
   it("retains a consistent Hermes install when rollback cannot remove its MCP entry", async () => {
     const home = await temporaryHome();
     const launcherPath = await launcher(home);

--- a/packages/bindings/src/hermes/full.ts
+++ b/packages/bindings/src/hermes/full.ts
@@ -722,7 +722,13 @@ export const createHermesHostBinding = (options: HermesHostBindingOptions): Host
       if (config === null)
         throw corrupt("Hermes config.yaml has an unreadable Distilly MCP entry.");
       const expected = expectedMcpEntry(wrapper);
-      if (config !== undefined && !mcpEqual(config, expected)) {
+      // An entry whose command is our own wrapper belongs to this install even when its
+      // tool toggles are not the expected ones yet: an interrupted setup can leave the host
+      // having written the command without the toggles, and refusing it dead-ended both
+      // setup and uninstall with no recovery but manual host surgery.
+      const oursByCommand =
+        config !== undefined && config.command === wrapper && config.args.length === 0;
+      if (config !== undefined && !oursByCommand && !mcpEqual(config, expected)) {
         throw invalid(
           "Hermes already has a different MCP server named distilly; rename it explicitly.",
         );
@@ -829,7 +835,29 @@ export const createHermesHostBinding = (options: HermesHostBindingOptions): Host
             lastObservedConfig = afterSet;
           }
         }
-        const finalConfig = await readHermesMcpEntry(homeDirectory);
+        let finalConfig = await readHermesMcpEntry(homeDirectory);
+        if (finalConfig !== undefined && finalConfig !== null && !mcpEqual(finalConfig, expected)) {
+          // The entry names our wrapper but is missing the exact shape: repair it with the
+          // host's own config command instead of failing, so an interrupted setup converges.
+          if (finalConfig.command !== wrapper || finalConfig.args.length > 0) {
+            throw commandFailed("configure");
+          }
+          configuredByDistilly = true;
+          for (const [key, value] of [
+            ["enabled", "true"],
+            ["tools.resources", "false"],
+            ["tools.prompts", "false"],
+          ] as const) {
+            const repaired = await runHost(options, homeDirectory, [
+              "config",
+              "set",
+              `mcp_servers.distilly.${key}`,
+              value,
+            ]);
+            if (repaired.exitCode !== 0) throw commandFailed("configure");
+          }
+          finalConfig = await readHermesMcpEntry(homeDirectory);
+        }
         if (finalConfig === undefined || finalConfig === null || !mcpEqual(finalConfig, expected)) {
           throw commandFailed("configure");
         }

--- a/packages/bindings/src/hermes/full.ts
+++ b/packages/bindings/src/hermes/full.ts
@@ -525,8 +525,18 @@ const isManagedMcpEntry = (entry: HermesMcpEntry, wrapper: string): boolean =>
   (entry.resources === true || entry.resources === false) &&
   (entry.prompts === true || entry.prompts === false);
 
+/**
+ * Reports whether one host test output announced exactly five discovered tools.
+ *
+ * A real Hermes v0.19.0 prefixes the line with a status glyph ("✓ Tools discovered: 5")
+ * while an older build printed the bare text, so any run of non-alphanumeric decoration is
+ * allowed before the phrase. The count itself stays exact: "15" cannot match.
+ *
+ * @param stdout - Captured standard output of one host `mcp test` run.
+ * @returns True when the output announced exactly five discovered tools.
+ */
 const discoveredExactlyFiveTools = (stdout: string): boolean =>
-  /(?:^|\r?\n)\s*Tools discovered:\s*5\s*(?:\r?\n|$)/u.test(stdout);
+  /(?:^|\r?\n)[^A-Za-z0-9\r\n]*Tools discovered:\s*5\s*(?:\r?\n|$)/u.test(stdout);
 
 const installSkill = async (
   sourceRoot: string,
@@ -757,10 +767,14 @@ export const createHermesHostBinding = (options: HermesHostBindingOptions): Host
           // command may write config and then return a non-zero status; the
           // rollback below must still inspect and clean that partial write.
           configuredByDistilly = true;
+          // `mcp add` is discovery-first: it starts the server and waits for its tool
+          // list before writing the entry. Distilly's launcher opens a SQLite store and
+          // validates its binding first, which a real Hermes v0.19.0 abandoned after its
+          // short default, so the entry landed disabled and setup failed verification.
           const added = await runHost(
             options,
             homeDirectory,
-            ["mcp", "add", "distilly", "--command", wrapper],
+            ["mcp", "add", "distilly", "--command", wrapper, "--connect-timeout", "20"],
             "y\n",
           );
           if (added.exitCode !== 0) throw commandFailed("configure");
@@ -772,7 +786,30 @@ export const createHermesHostBinding = (options: HermesHostBindingOptions): Host
           ) {
             throw commandFailed("configure");
           }
-          lastObservedConfig = afterAdd;
+          // A discovery that still failed is recoverable: the entry names our wrapper, so
+          // enabling it is the operator's own setup request and the five-tool check below
+          // is what actually proves the integration.
+          if (afterAdd.enabled === false) {
+            const enabled = await runHost(options, homeDirectory, [
+              "config",
+              "set",
+              "mcp_servers.distilly.enabled",
+              "true",
+            ]);
+            if (enabled.exitCode !== 0) throw commandFailed("configure");
+            const afterEnable = await readHermesMcpEntry(homeDirectory);
+            if (
+              afterEnable === undefined ||
+              afterEnable === null ||
+              !isManagedMcpEntry(afterEnable, wrapper) ||
+              afterEnable.enabled !== true
+            ) {
+              throw commandFailed("configure");
+            }
+            lastObservedConfig = afterEnable;
+          } else {
+            lastObservedConfig = afterAdd;
+          }
           for (const key of ["resources", "prompts"] as const) {
             const result = await runHost(options, homeDirectory, [
               "config",

--- a/packages/cli/src/harvest.ts
+++ b/packages/cli/src/harvest.ts
@@ -18,6 +18,8 @@ export interface HarvestFile {
   readonly mediaType: string;
   /** Root-relative path with POSIX separators, used for deterministic ordering. */
   readonly relativePath: string;
+  /** Size in bytes, used to decide whether one file must be ingested on its own. */
+  readonly sizeBytes: number;
 }
 
 /** Complete, deterministic result of selecting evidence from one directory. */
@@ -179,7 +181,7 @@ export const selectHarvestFiles = async (
         return;
       }
       labels.add(pathLabel);
-      files.push({ path, pathLabel, mediaType, relativePath });
+      files.push({ path, pathLabel, mediaType, relativePath, sizeBytes: metadata.size });
     }
   };
 

--- a/packages/cli/src/lifecycle.test.ts
+++ b/packages/cli/src/lifecycle.test.ts
@@ -311,6 +311,36 @@ exit 0
     });
   });
 
+  it("accepts a source-install provenance suffix on the Hermes version line", async () => {
+    // A real source install prints "Hermes Agent v0.19.0 (2026.7.20) · upstream 01906e99".
+    // The suffix is dropped so a rebuild of the same release is not read as an upgrade and
+    // the host is not rejected as an invalid version.
+    const home = await mkdtemp(join(tmpdir(), "distilly-hermes-version-"));
+    temporaryRoots.push(home);
+    const bin = join(home, "bin");
+    await mkdir(bin, { recursive: true });
+    const hermes = join(bin, "hermes");
+    await executable(hermes, "Hermes Agent v0.19.0 (2026.7.20) · upstream 01906e99");
+
+    const failure = await setupPreviewHost(
+      BUILTIN_HOSTS.hermes,
+      {
+        homeDirectory: home,
+        nodePath: process.execPath,
+        entryPath: join(home, "entry.js"),
+        pluginSourcesPath: join(home, "plugins"),
+        pathValue: bin,
+      },
+      { allowUnverifiedHost: true },
+    ).then(
+      () => undefined,
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    // The probe must not be the failing step; whatever fails later, it is never the version.
+    expect(failure).toBeDefined();
+    expect(failure).not.toMatch(/invalid version/u);
+  });
+
   it("fails before writing when the observed host version has no exact fixture", async () => {
     const { root, home, environment } = await fixture();
     await executable(join(root, "host-bin", "codex"), "codex-cli 99.0.0");

--- a/packages/cli/src/lifecycle.ts
+++ b/packages/cli/src/lifecycle.ts
@@ -927,6 +927,41 @@ export const setupPreviewHost = async (
       .then((health) => health.installed)
       .catch(() => false));
   let bindingInstalled = false;
+  // Two-phase install. A host can verify the integration by connecting to Distilly's
+  // launcher during its own install step (Hermes discovers tools inside `mcp add`), and
+  // that launcher resolves its binding from this manifest. Writing the manifest only
+  // after the projection succeeded deadlocked every discovery-first host, so the entry is
+  // written first and restored if anything below fails.
+  const priorHost = previous?.hosts.find((entry) => entry.host === host);
+  const hostEntry: InstalledHost =
+    priorHost === undefined
+      ? {
+          host,
+          executablePath,
+          hostVersion,
+          installedAt: isoDateTimeSchema.parse(
+            (environment.now ?? (() => new Date()))().toISOString(),
+          ),
+          ...(unverifiedHost === undefined ? {} : { unverifiedHostVersion: unverifiedHost }),
+        }
+      : unverifiedHost === undefined
+        ? { ...withoutUnverifiedFlag(priorHost), executablePath, hostVersion }
+        : { ...priorHost, executablePath, hostVersion, unverifiedHostVersion: unverifiedHost };
+  const hosts = [...(previous?.hosts.filter((entry) => entry.host !== host) ?? []), hostEntry].sort(
+    (left, right) => compareUtf8(left.host, right.host),
+  );
+  await writeManifest(paths.install, {
+    schemaVersion: 1,
+    releaseVersion: release.releaseVersion,
+    wireMajor: 3,
+    nodePath: environment.nodePath,
+    entryPath: installedEntry,
+    launcherPath: paths.launcher,
+    launcherDigest,
+    runtimePath: paths.runtime,
+    runtimeDigest,
+    hosts,
+  });
   try {
     const installed = await binding.installPlugin(
       installContext(paths, release, installedPlugins, host),
@@ -942,37 +977,6 @@ export const setupPreviewHost = async (
     ) {
       throw fail(`Distilly setup could not verify the ${host} integration.`);
     }
-    const priorHost = previous?.hosts.find((entry) => entry.host === host);
-    const hostEntry: InstalledHost =
-      priorHost === undefined
-        ? {
-            host,
-            executablePath,
-            hostVersion,
-            installedAt: isoDateTimeSchema.parse(
-              (environment.now ?? (() => new Date()))().toISOString(),
-            ),
-            ...(unverifiedHost === undefined ? {} : { unverifiedHostVersion: unverifiedHost }),
-          }
-        : unverifiedHost === undefined
-          ? { ...withoutUnverifiedFlag(priorHost), executablePath, hostVersion }
-          : { ...priorHost, executablePath, hostVersion, unverifiedHostVersion: unverifiedHost };
-    const hosts = [
-      ...(previous?.hosts.filter((entry) => entry.host !== host) ?? []),
-      hostEntry,
-    ].sort((left, right) => compareUtf8(left.host, right.host));
-    await writeManifest(paths.install, {
-      schemaVersion: 1,
-      releaseVersion: release.releaseVersion,
-      wireMajor: 3,
-      nodePath: environment.nodePath,
-      entryPath: installedEntry,
-      launcherPath: paths.launcher,
-      launcherDigest,
-      runtimePath: paths.runtime,
-      runtimeDigest,
-      hosts,
-    });
     return {
       host,
       launcherPath: paths.launcher,
@@ -980,6 +984,10 @@ export const setupPreviewHost = async (
       restartRequired: true,
     };
   } catch (error) {
+    // Restore the manifest this attempt replaced, so a failed projection leaves no entry
+    // claiming a host that is not installed.
+    if (previous === undefined) await removeIfPresent(paths.install);
+    else await writeManifest(paths.install, previous).catch(() => undefined);
     if (bindingInstalled && !existed && !preexistingBinding) {
       await binding
         .uninstallPlugin(installContext(paths, release, installedPlugins, host))

--- a/packages/cli/src/lifecycle.ts
+++ b/packages/cli/src/lifecycle.ts
@@ -607,11 +607,15 @@ const normalizeHostVersion = (host: HostName, stdout: string): string => {
     .split(/\r?\n/u)
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
-  // Hermes prints a short version line followed by diagnostic metadata. Keep
-  // only the stable first line so an upgrade does not make the manifest noisy.
+  // Hermes prints a short version line followed by diagnostic metadata. Keep only the
+  // stable first line so an upgrade does not make the manifest noisy.
   if (host === BUILTIN_HOSTS.hermes) {
     const first = lines[0] ?? "";
-    return /^Hermes Agent v\S+(?:\s+\([^\r\n]+\))?$/u.test(first) ? first : "";
+    // A source install appends provenance ("· upstream 01906e99") to that line. It is
+    // dropped rather than matched so a rebuild of the same release does not read as a host
+    // upgrade, and a host whose line carries it is not rejected outright.
+    const match = /^(Hermes Agent v\S+(?:\s+\([^\r\n]+\))?)(?:\s+·.*)?$/u.exec(first);
+    return match === null ? "" : match[1]!;
   }
   return lines.length === 1 ? lines[0]! : "";
 };

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -235,11 +235,28 @@ const runHarvest = async (
   }
   const application = await openApplication(options.host, environment);
   try {
-    const batchSize = WIRE_LIMITS.ingestMaterials;
+    // A file larger than one material is split by the runtime into parts, so it must travel
+    // alone: a batch of several oversized files could exceed the wire limit for one result.
+    const batches: (readonly (typeof selection.files)[number][])[] = [];
+    let pending: (typeof selection.files)[number][] = [];
+    for (const file of selection.files) {
+      if (file.sizeBytes > WIRE_LIMITS.materialContentBytes) {
+        if (pending.length > 0) batches.push(pending);
+        batches.push([file]);
+        pending = [];
+        continue;
+      }
+      pending.push(file);
+      if (pending.length === WIRE_LIMITS.ingestMaterials) {
+        batches.push(pending);
+        pending = [];
+      }
+    }
+    if (pending.length > 0) batches.push(pending);
+
     let subjectId: string | undefined = options.subjectId;
     let ingested = 0;
-    for (let start = 0; start < selection.files.length; start += batchSize) {
-      const batch = selection.files.slice(start, start + batchSize);
+    for (const batch of batches) {
       const result = await application.distilly.ingestFiles({
         subject:
           subjectId === undefined

--- a/packages/engine/src/ingest/service.ts
+++ b/packages/engine/src/ingest/service.ts
@@ -2,6 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 
 import {
   DistillyError,
+  WIRE_LIMITS,
   actorContextSchema,
   briefContractSchema,
   contentDigestSchema,
@@ -723,11 +724,23 @@ const rawIdentity = (
   };
 };
 
+/**
+ * Validates the trusted file loader's records for one file-ingest call.
+ *
+ * The loader may return MORE records than requested paths because one oversized file is
+ * split into parts that each fit the material limit. The count therefore only has a lower
+ * bound, while the wire limit for one result stays the upper bound; every record is still
+ * checked below, and a split never loses or reorders the parts it reports.
+ *
+ * @param loaded - Records returned by the trusted loader.
+ * @param expectedCount - Number of paths the caller supplied.
+ * @returns The validated records, unchanged.
+ */
 const assertTrustedLoadedFiles = (
   loaded: readonly TrustedLoadedFile[],
   expectedCount: number,
 ): readonly TrustedLoadedFile[] => {
-  if (loaded.length !== expectedCount) {
+  if (loaded.length < expectedCount || loaded.length > WIRE_LIMITS.ingestMaterials) {
     throw storageCorrupt("The trusted file loader returned an invalid item count.");
   }
   const labels = new Set<string>();

--- a/packages/protocol/src/values/materials.ts
+++ b/packages/protocol/src/values/materials.ts
@@ -144,6 +144,12 @@ export type FileIngestItemResult =
       readonly kind: "parsed";
       readonly pathLabel: string;
       readonly material: IngestItemResult;
+      /**
+       * Parser observations about a file that was accepted, such as skipped attachments, an
+       * ambiguous separator, or a split into parts. A parsed file is not the same as a file
+       * parsed completely, and these were previously computed and dropped.
+       */
+      readonly warnings: readonly string[];
     }
   | {
       readonly kind: "unparsed";

--- a/packages/runtime/src/preview.test.ts
+++ b/packages/runtime/src/preview.test.ts
@@ -95,6 +95,39 @@ afterEach(async () => {
 });
 
 describe("Developer Preview LocalRuntime", () => {
+  it("splits one oversized local file into parts that each fit the material limit", async () => {
+    const root = await temporaryRoot();
+    const inputRoot = await temporaryRoot();
+    const path = join(inputRoot, "huge-chat.txt");
+    // Three lines of 700 KB each: every pair exceeds the 1 MiB material limit, so the split
+    // must land on line boundaries and produce exactly three parts.
+    const line = `${"x".repeat(700_000)}\n`;
+    await writeFile(path, line.repeat(3));
+
+    const runtime = await open(root);
+    const client = await connect(runtime, "file-split");
+    const result = await client.call(
+      "materials.ingestFiles",
+      {
+        subject: { kind: "create" as const, input: { displayName: "Huge", identityHints: [] } },
+        paths: [path],
+        enqueue: "now" as const,
+      },
+      { requestId: request() },
+    );
+
+    expect(result.items).toHaveLength(3);
+    expect(result.items.map((item) => item.pathLabel)).toEqual([
+      "huge-chat.txt [part 1 of 3]",
+      "huge-chat.txt [part 2 of 3]",
+      "huge-chat.txt [part 3 of 3]",
+    ]);
+    for (const item of result.items) {
+      expect(item.kind).toBe("parsed");
+      expect(item.warnings.join(" ")).toContain("Split into 3 parts");
+    }
+  });
+
   it("atomically ingests parsed and unparsed local files, replays before reads, and reopens", async () => {
     const root = await temporaryRoot();
     const inputRoot = await temporaryRoot();

--- a/packages/runtime/src/preview.ts
+++ b/packages/runtime/src/preview.ts
@@ -128,6 +128,54 @@ const assertNoSymlinkFile = async (path: string): Promise<void> => {
   if (metadata.isSymbolicLink()) throw new Error("symlinked local path");
 };
 
+/**
+ * Splits rendered material text into parts that each fit the local material limit.
+ *
+ * Text is cut at line boundaries so a part never begins mid-line, except when one line is
+ * itself larger than the limit, which is then cut by characters. Deterministic: the same
+ * text always yields the same parts.
+ *
+ * @param text - Rendered material text.
+ * @param maximumBytes - Largest UTF-8 byte length one part may have.
+ * @returns One or more part texts, in order.
+ */
+const splitParsedText = (text: string, maximumBytes: number): readonly string[] => {
+  const encoder = new TextEncoder();
+  const parts: string[] = [];
+  let current: string[] = [];
+  let currentBytes = 0;
+  const flush = (): void => {
+    if (current.length === 0) return;
+    parts.push(current.join("\n"));
+    current = [];
+    currentBytes = 0;
+  };
+  for (const line of text.split("\n")) {
+    let remaining = line;
+    for (;;) {
+      const lineBytes = encoder.encode(remaining).byteLength;
+      if (lineBytes <= maximumBytes) break;
+      // One line exceeds a whole part: cut it by characters at the byte boundary.
+      let cut = remaining.length;
+      while (cut > 1 && encoder.encode(remaining.slice(0, cut)).byteLength > maximumBytes) {
+        cut -= 1;
+      }
+      flush();
+      parts.push(remaining.slice(0, cut));
+      remaining = remaining.slice(cut);
+    }
+    const lineBytes = encoder.encode(remaining).byteLength + 1;
+    if (currentBytes + lineBytes > maximumBytes) flush();
+    current.push(remaining);
+    currentBytes += lineBytes;
+  }
+  flush();
+  return parts;
+};
+
+/** Largest rendered text the loader accepts before it must split into parts. */
+const MAXIMUM_PARSED_TEXT_BYTES = WIRE_LIMITS.materialContentBytes * WIRE_LIMITS.ingestMaterials;
+
 const createLocalFileLoader = () => {
   const registry = createBuiltinParserRegistry();
   return {
@@ -153,7 +201,7 @@ const createLocalFileLoader = () => {
         }
         labels.add(pathLabel);
       });
-      return Promise.all(
+      const perPath = await Promise.all(
         input.paths.map(async (path, index) => {
           const pathLabel = basename(path);
           let bytes: Uint8Array;
@@ -205,11 +253,54 @@ const createLocalFileLoader = () => {
               {
                 subjectId: input.subjectId,
                 requestId: input.requestId,
-                maximumOutputBytes: WIRE_LIMITS.materialContentBytes,
+                maximumOutputBytes: MAXIMUM_PARSED_TEXT_BYTES,
               },
             );
           } catch (error) {
             return { pathLabel, mediaType, bytes, source, warnings: [parserWarning(error)] };
+          }
+          if (
+            parsed.material !== undefined &&
+            new TextEncoder().encode(parsed.material.content).byteLength >
+              WIRE_LIMITS.materialContentBytes
+          ) {
+            const parts = splitParsedText(
+              parsed.material.content,
+              WIRE_LIMITS.materialContentBytes,
+            );
+            if (parts.length > WIRE_LIMITS.ingestMaterials) {
+              // More parts than one ingest call can carry: refuse rather than drop any.
+              return {
+                pathLabel,
+                mediaType,
+                bytes,
+                source,
+                warnings: [
+                  `The parsed text needs ${String(parts.length)} parts, more than one ingest call carries; narrow the file.`,
+                ],
+              };
+            }
+            return parts.map((part, index) => {
+              // The label may not contain "/" or "\\": the engine treats it as a label, not a path.
+              const partLabel = `${pathLabel} [part ${String(index + 1)} of ${String(parts.length)}]`;
+              return {
+                pathLabel: partLabel,
+                mediaType,
+                bytes: new TextEncoder().encode(part),
+                source: { ...source, title: partLabel },
+                parsed: {
+                  ...parsed.material!,
+                  clientRef: partLabel,
+                  content: part,
+                  source: { ...parsed.material!.source, title: partLabel },
+                  sensitivity: input.sensitivity,
+                },
+                warnings: [
+                  ...parsed.warnings,
+                  `Split into ${String(parts.length)} parts to fit the local material limit.`,
+                ],
+              };
+            });
           }
           return {
             pathLabel,
@@ -223,6 +314,7 @@ const createLocalFileLoader = () => {
           };
         }),
       );
+      return perPath.flat();
     },
   };
 };


### PR DESCRIPTION
## What
feat(cli): Hermes lifecycle on a real host; runtime splits oversized files

## Commits
- feat(cli): complete the Hermes lifecycle on a real host
- feat(runtime): split an oversized local file into materials
- fix: recover from a source-install version line and an interrupted Hermes setup

## Stack
Stacked on `pr/05-unverified-floor`; the whole series ends at `distilly-work` (`0bd924e`).

## Verification
Every feature carries an author report and an independent audit in the delivery evidence folder (`host-verification/`), including screenshots and the audit verdict that drove the fixes. Gates on the top of the stack: format, lint, docs, release check, and 1163 tests.

## Real hosts
Codex, Claude Code 2.1.268, OpenClaw 2026.9.2, Hermes v0.19.0, and DSH 0.1.5-rc.1 were each exercised end to end (install, host-visible confirmation, exactly five MCP tools, person Skill install/remove, uninstall). Capacity fixtures are recorded for Codex 0.146.0, OpenClaw 2026.3.24, and Hermes v0.9.0; newer host versions run on the labelled conservative floor.

## Evidence
Author reports and screenshots (delivery evidence folder `host-verification/`):
- f12-hermes-lifecycle-REPORT.md, hermes-lifecycle.png, hermes-lifecycle-evidence.txt, hermes-host-drift.png
- f3-large-file-split-REPORT.md

Independent audit reports:
- round7-hermes-and-round8-fixes-REPORT.md, round9-VERIFY.md, round10-VERIFY.md