### PR TITLE
feat(cli): resolve people by name, show profile gaps; byte-exact file splitting

### DIFF
--- a/packages/cli/src/harvest.test.ts
+++ b/packages/cli/src/harvest.test.ts
@@ -2,9 +2,10 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { DistillyError } from "@distilly/protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { describeHarvestSelection, selectHarvestFiles } from "./harvest.js";
+import { describeHarvestSelection, recordBudgetExceeded, selectHarvestFiles } from "./harvest.js";
 
 const temporaryRoots: string[] = [];
 
@@ -118,5 +119,37 @@ describe("directory harvest selection", () => {
 
     expect(lines[0]).toBe("Selected 1 file(s) from 1 director(ies).");
     expect(lines.slice(1)).toEqual(["  skipped credential: 1", "  skipped unsupported-format: 1"]);
+  });
+});
+
+describe("record budget classification", () => {
+  it("recognizes the runtime's record-budget refusal and nothing else", () => {
+    const budget = new DistillyError({
+      code: "invalid_input",
+      message:
+        "This selection expands to 33 material records, more than the 32 one ingest call carries.",
+      retryable: false,
+      details: { reason: "record_budget_exceeded", records: 33, maximumRecords: 32 },
+    });
+    expect(recordBudgetExceeded(budget)).toBe(true);
+    expect(
+      recordBudgetExceeded(
+        new DistillyError({
+          code: "invalid_input",
+          message: "The materials.ingest boundary input is invalid.",
+          retryable: false,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      recordBudgetExceeded(
+        new DistillyError({
+          code: "storage_corrupt",
+          message: "The trusted file loader returned an invalid item count.",
+          retryable: false,
+        }),
+      ),
+    ).toBe(false);
+    expect(recordBudgetExceeded(new Error("record_budget_exceeded"))).toBe(false);
   });
 });

--- a/packages/cli/src/harvest.ts
+++ b/packages/cli/src/harvest.ts
@@ -1,6 +1,23 @@
 import { lstat, readdir } from "node:fs/promises";
 import { basename, extname, join, relative, sep } from "node:path";
 
+import { DistillyError } from "@distilly/protocol";
+
+/**
+ * Reports whether one ingest call refused the selection for expanding past the record budget.
+ *
+ * The runtime raises this when the selected files parse into more material records than one
+ * call carries, which is not the same failure as an unreadable file: the caller can still make
+ * progress by sending fewer files, so it must be recognizable instead of matched by message.
+ *
+ * @param error - Error thrown by an ingest call.
+ * @returns True when the selection must be split into smaller calls.
+ */
+export const recordBudgetExceeded = (error: unknown): boolean =>
+  error instanceof DistillyError &&
+  error.code === "invalid_input" &&
+  error.details?.["reason"] === "record_budget_exceeded";
+
 /** Why one discovered path was not selected as evidence. */
 export type HarvestSkipReason =
   | "credential"

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -21,6 +21,7 @@ describe("Developer Preview CLI host boundary", () => {
     ["mcp", ["mcp", "--host", "other-host"]],
     ["panel", ["panel", "--host", "other-host"]],
     ["harvest", ["harvest", "/tmp/evidence", "--host", "other-host", "--name", "Ada"]],
+    ["show", ["show", `subject_${"a".repeat(32)}`, "--host", "other-host"]],
     ["person install", ["install", `subject_${"a".repeat(32)}`, "--host", "other-host"]],
   ])(
     "offers an explicit legacy guide for unsupported %s without switching modes",
@@ -55,6 +56,44 @@ describe("Developer Preview CLI host boundary", () => {
 
     expect(stdout.join("")).toContain("Legacy Skill compatibility path documented in INSTALL.md");
     expect(stderr).toEqual([]);
+  });
+
+  it("requires a subject id or name and a host for show", async () => {
+    const io = {
+      stdout: { write: (value: string) => value },
+      stderr: { write: (value: string) => value },
+    };
+    await expect(runPreviewCli(["show", "--host", "codex"], environment, io)).rejects.toThrow(
+      "This command requires a subject id or display name, then --host <host>.",
+    );
+    await expect(
+      runPreviewCli(["show", `subject_${"a".repeat(32)}`], environment, io),
+    ).rejects.toThrow("This command requires --host.");
+    await expect(
+      runPreviewCli(
+        ["show", `subject_${"a".repeat(32)}`, "--host", "codex", "--nope", "1"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("Unknown show option: --nope.");
+  });
+
+  it("requires a host for the subjects listing and rejects unknown options", async () => {
+    const stdout: string[] = [];
+    const io = {
+      stdout: { write: (value: string) => stdout.push(value) },
+      stderr: { write: (value: string) => value },
+    };
+    await expect(runPreviewCli(["subjects"], environment, io)).rejects.toThrow(
+      "This command requires --host.",
+    );
+    await expect(
+      runPreviewCli(["subjects", "--host", "codex", "--nope", "1"], environment, io),
+    ).rejects.toThrow("Unknown subjects option: --nope.");
+    await expect(
+      runPreviewCli(["subjects", "--host", "codex", "--limit", "0"], environment, io),
+    ).rejects.toThrow("--limit must be positive.");
+    expect(stdout).toEqual([]);
   });
 
   it("requires a directory and exactly one subject selector for harvest", async () => {
@@ -97,6 +136,8 @@ describe("Developer Preview CLI host boundary", () => {
 
     expect(stdout.join("")).toContain("distilly panel --host <host>");
     expect(stdout.join("")).toContain("distilly harvest <directory>");
+    expect(stdout.join("")).toContain("distilly subjects --host <host>");
+    expect(stdout.join("")).toContain("distilly show <subject-id|display-name>");
     expect(stdout.join("")).toContain("codex | claude-code | openclaw | hermes | dsh");
     expect(stderr).toEqual([]);
   });

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -22,7 +22,7 @@ import {
   uninstallPreviewHost,
   type PreviewLifecycleEnvironment,
 } from "./lifecycle.js";
-import { describeHarvestSelection, selectHarvestFiles } from "./harvest.js";
+import { describeHarvestSelection, recordBudgetExceeded, selectHarvestFiles } from "./harvest.js";
 import {
   describeAmbiguousSubject,
   describePendingProfile,
@@ -273,58 +273,89 @@ const runHarvest = async (
 
     let subjectId: string | undefined = options.subjectId;
     let ingested = 0;
-    for (const batch of batches) {
-      // Harvest is an explicit user action, so distillation is queued now instead of
-      // waiting for the engine's automatic threshold: a single small file previously
-      // produced no job and no message, which read as nothing having happened.
-      const ingest = async (
-        target:
-          | { readonly kind: "create"; readonly input: { readonly displayName: string } }
-          | { readonly kind: "existing"; readonly subjectId: string },
-      ) =>
-        await application.distilly.ingestFiles({
-          subject:
-            target.kind === "create"
-              ? { kind: "create", input: target.input }
-              : { kind: "existing", subjectId: subjectIdSchema.parse(target.subjectId) },
-          paths: batch.map((file) => file.path),
-          enqueue: "now",
-          ...(options.sensitivity === undefined ? {} : { sensitivity: options.sensitivity }),
-        });
-      let result;
+    const failures: string[] = [];
+    // Harvest is an explicit user action, so distillation is queued now instead of waiting for
+    // the engine's automatic threshold: a single small file previously produced no job and no
+    // message, which read as nothing having happened.
+    const ingest = async (
+      target:
+        | { readonly kind: "create"; readonly input: { readonly displayName: string } }
+        | { readonly kind: "existing"; readonly subjectId: string },
+      files: readonly (typeof selection.files)[number][],
+    ) =>
+      await application.distilly.ingestFiles({
+        subject:
+          target.kind === "create"
+            ? { kind: "create", input: target.input }
+            : { kind: "existing", subjectId: subjectIdSchema.parse(target.subjectId) },
+        paths: files.map((file) => file.path),
+        enqueue: "now",
+        ...(options.sensitivity === undefined ? {} : { sensitivity: options.sensitivity }),
+      });
+    const ingestTarget = () =>
+      subjectId === undefined
+        ? ({ kind: "create", input: { displayName: options.displayName ?? "" } } as const)
+        : ({ kind: "existing", subjectId } as const);
+    const ingestWithSubjectReuse = async (files: readonly (typeof selection.files)[number][]) => {
       try {
-        result = await ingest(
-          subjectId === undefined
-            ? { kind: "create", input: { displayName: options.displayName ?? "" } }
-            : { kind: "existing", subjectId },
-        );
+        return await ingest(ingestTarget(), files);
       } catch (error) {
-        // A second harvest for the same person is normal, not an error: the engine refuses
-        // to guess between people and answers with the exact subject it matched. Reusing
-        // that subject keeps the one-shot flow working instead of failing on a duplicate.
+        // A second harvest for the same person is normal, not an error: the engine refuses to
+        // guess between people and answers with the exact subject it matched. Reusing that
+        // subject keeps the one-shot flow working instead of failing on a duplicate.
         const reuse = reusableSubject(error);
         if (reuse !== undefined) {
           subjectId = reuse.id;
           io.stdout.write(
             `${reuse.displayName} (${reuse.id}) already exists, so this material was added to it.\n`,
           );
-          result = await ingest({ kind: "existing", subjectId: reuse.id });
-        } else {
-          const candidates = ambiguousCandidates(error);
-          if (candidates === undefined) throw error;
-          for (const line of describeAmbiguousSubject(options.displayName ?? "", candidates)) {
-            io.stdout.write(`${line}\n`);
-          }
-          throw new Error(
-            "More than one subject matches that name. Repeat harvest with --subject <subject-id>.",
-            { cause: error },
-          );
+          return await ingest({ kind: "existing", subjectId: reuse.id }, files);
         }
+        const candidates = ambiguousCandidates(error);
+        if (candidates === undefined) throw error;
+        for (const line of describeAmbiguousSubject(options.displayName ?? "", candidates)) {
+          io.stdout.write(`${line}\n`);
+        }
+        throw new Error(
+          "More than one subject matches that name. Repeat harvest with --subject <subject-id>.",
+          { cause: error },
+        );
       }
+    };
+    const recordResult = (
+      result: { subject: { id: string; displayName: string } },
+      count: number,
+    ) => {
       subjectId = result.subject.id;
-      ingested += batch.length;
+      ingested += count;
       io.stdout.write(
         `Ingested ${String(ingested)}/${String(selection.files.length)} file(s) as ${result.subject.displayName} (${result.subject.id}).\n`,
+      );
+    };
+    for (const batch of batches) {
+      try {
+        recordResult(await ingestWithSubjectReuse(batch), batch.length);
+      } catch (error) {
+        // A batch can exceed the record budget because one file splits into several records.
+        // Retry that batch one file per call so one expanding file cannot lose the others.
+        if (!recordBudgetExceeded(error) || batch.length === 1) throw error;
+        io.stdout.write(
+          "That batch expands past one call's record budget; ingesting its files one at a time.\n",
+        );
+        for (const file of batch) {
+          try {
+            recordResult(await ingestWithSubjectReuse([file]), 1);
+          } catch (fileError) {
+            const reason = fileError instanceof Error ? fileError.message : "unknown failure";
+            failures.push(`${file.pathLabel}: ${reason}`);
+            io.stdout.write(`Skipped ${file.pathLabel}: ${reason}\n`);
+          }
+        }
+      }
+    }
+    if (failures.length > 0) {
+      throw new Error(
+        `${String(failures.length)} of ${String(selection.files.length)} file(s) could not be ingested:\n${failures.join("\n")}`,
       );
     }
   } finally {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -3,7 +3,17 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { lstat, realpath } from "node:fs/promises";
 
-import { BUILTIN_HOSTS, WIRE_LIMITS, subjectIdSchema, type HostName } from "@distilly/protocol";
+import {
+  BUILTIN_HOSTS,
+  DistillyError,
+  WIRE_LIMITS,
+  subjectIdSchema,
+  type HostName,
+  type SubjectSummary,
+} from "@distilly/protocol";
+import type { Distilly } from "distilly";
+
+import { ambiguousCandidates, reusableSubject } from "./subject-errors.js";
 
 import {
   doctorPreview,
@@ -13,6 +23,13 @@ import {
   type PreviewLifecycleEnvironment,
 } from "./lifecycle.js";
 import { describeHarvestSelection, selectHarvestFiles } from "./harvest.js";
+import {
+  describeAmbiguousSubject,
+  describePendingProfile,
+  describeProfile,
+  describeSubjectList,
+  looksLikeSubjectId,
+} from "./show.js";
 import {
   PREVIEW_PANEL_ASSETS,
   PREVIEW_PLUGIN_SOURCES,
@@ -257,21 +274,199 @@ const runHarvest = async (
     let subjectId: string | undefined = options.subjectId;
     let ingested = 0;
     for (const batch of batches) {
-      const result = await application.distilly.ingestFiles({
-        subject:
+      // Harvest is an explicit user action, so distillation is queued now instead of
+      // waiting for the engine's automatic threshold: a single small file previously
+      // produced no job and no message, which read as nothing having happened.
+      const ingest = async (
+        target:
+          | { readonly kind: "create"; readonly input: { readonly displayName: string } }
+          | { readonly kind: "existing"; readonly subjectId: string },
+      ) =>
+        await application.distilly.ingestFiles({
+          subject:
+            target.kind === "create"
+              ? { kind: "create", input: target.input }
+              : { kind: "existing", subjectId: subjectIdSchema.parse(target.subjectId) },
+          paths: batch.map((file) => file.path),
+          enqueue: "now",
+          ...(options.sensitivity === undefined ? {} : { sensitivity: options.sensitivity }),
+        });
+      let result;
+      try {
+        result = await ingest(
           subjectId === undefined
             ? { kind: "create", input: { displayName: options.displayName ?? "" } }
-            : { kind: "existing", subjectId: subjectIdSchema.parse(subjectId) },
-        paths: batch.map((file) => file.path),
-        enqueue: "auto",
-        ...(options.sensitivity === undefined ? {} : { sensitivity: options.sensitivity }),
-      });
+            : { kind: "existing", subjectId },
+        );
+      } catch (error) {
+        // A second harvest for the same person is normal, not an error: the engine refuses
+        // to guess between people and answers with the exact subject it matched. Reusing
+        // that subject keeps the one-shot flow working instead of failing on a duplicate.
+        const reuse = reusableSubject(error);
+        if (reuse !== undefined) {
+          subjectId = reuse.id;
+          io.stdout.write(
+            `${reuse.displayName} (${reuse.id}) already exists, so this material was added to it.\n`,
+          );
+          result = await ingest({ kind: "existing", subjectId: reuse.id });
+        } else {
+          const candidates = ambiguousCandidates(error);
+          if (candidates === undefined) throw error;
+          for (const line of describeAmbiguousSubject(options.displayName ?? "", candidates)) {
+            io.stdout.write(`${line}\n`);
+          }
+          throw new Error(
+            "More than one subject matches that name. Repeat harvest with --subject <subject-id>.",
+            { cause: error },
+          );
+        }
+      }
       subjectId = result.subject.id;
       ingested += batch.length;
       io.stdout.write(
         `Ingested ${String(ingested)}/${String(selection.files.length)} file(s) as ${result.subject.displayName} (${result.subject.id}).\n`,
       );
     }
+  } finally {
+    await application.close();
+  }
+};
+
+/**
+ * Resolves a name or id argument to one subject, refusing to guess between candidates.
+ *
+ * @param distilly - Connected facade owning the local runtime.
+ * @param argument - Subject id or display name typed by the operator.
+ * @param io - Command output streams, used when a name matches several subjects.
+ * @returns The resolved subject summary.
+ */
+const resolveSubjectArgument = async (
+  distilly: Distilly,
+  argument: string,
+  io: PreviewCliIo,
+): Promise<SubjectSummary> => {
+  const resolution = await distilly.resolve(
+    looksLikeSubjectId(argument)
+      ? { selector: { kind: "id", subjectId: subjectIdSchema.parse(argument) } }
+      : { selector: { kind: "query", query: argument } },
+  );
+  if (resolution.kind === "found") return resolution.subject;
+  if (resolution.kind === "ambiguous") {
+    for (const line of describeAmbiguousSubject(argument, resolution.candidates)) {
+      io.stdout.write(`${line}\n`);
+    }
+    throw new Error(`More than one subject matches "${argument}".`);
+  }
+  throw new Error(
+    `No subject matches "${argument}". Harvest their material first: distilly harvest <directory> --host <host> --name "${argument}".`,
+  );
+};
+
+/**
+ * Prints one profile with its maturity, evidence counts, and missing material.
+ *
+ * @param args - Subject id or display name, plus optional --host and --json.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ */
+const runShow = async (
+  args: readonly string[],
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<void> => {
+  const [subjectArgument, ...rest] = args;
+  if (subjectArgument === undefined || subjectArgument.startsWith("--")) {
+    throw new Error("This command requires a subject id or display name, then --host <host>.");
+  }
+  let host: HostName | undefined;
+  let asJson = false;
+  for (let index = 0; index < rest.length; index += 1) {
+    const flag = rest[index];
+    if (flag === "--json") {
+      asJson = true;
+      continue;
+    }
+    const value = rest[index + 1];
+    if (value === undefined) throw new Error(`Missing value for ${String(flag)}.`);
+    if (flag === "--host") host = parseHost(value);
+    else throw new Error(`Unknown show option: ${String(flag)}.`);
+    index += 1;
+  }
+  if (host === undefined) throw new Error("This command requires --host.");
+  const application = await openApplication(host, environment);
+  try {
+    const subject = await resolveSubjectArgument(application.distilly, subjectArgument, io);
+    const person = application.distilly.person(subject.id);
+    const status = await person.status();
+    let profile;
+    try {
+      profile = await person.get();
+    } catch (error) {
+      // A harvested person with no committed version is the normal first state, not a fault:
+      // report the queued distillation instead of the engine's not-found message.
+      if (!(error instanceof DistillyError) || error.code !== "not_found") throw error;
+      if (asJson) {
+        io.stdout.write(`${JSON.stringify({ profile: null, status }, undefined, 2)}\n`);
+        return;
+      }
+      io.stdout.write(`${describePendingProfile(subject, status).join("\n")}\n`);
+      return;
+    }
+    if (asJson) {
+      io.stdout.write(`${JSON.stringify({ profile, status }, undefined, 2)}\n`);
+      return;
+    }
+    const report = describeProfile(profile, status);
+    io.stdout.write(`${report.lines.join("\n")}\n`);
+  } finally {
+    await application.close();
+  }
+};
+
+/**
+ * Lists the people this local store knows about, so no one has to remember an id.
+ *
+ * @param args - Optional --host, --query, --limit, --cursor, and --json.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ */
+const runSubjects = async (
+  args: readonly string[],
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<void> => {
+  let host: HostName | undefined;
+  let asJson = false;
+  const query: { text?: string; limit?: number; cursor?: string } = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    if (flag === "--json") {
+      asJson = true;
+      continue;
+    }
+    const value = args[index + 1];
+    if (value === undefined) throw new Error(`Missing value for ${String(flag)}.`);
+    if (flag === "--host") host = parseHost(value);
+    else if (flag === "--query") query.text = value;
+    else if (flag === "--cursor") query.cursor = value;
+    else if (flag === "--limit") {
+      const limit = Number.parseInt(value, 10);
+      if (!Number.isSafeInteger(limit) || limit <= 0) throw new Error("--limit must be positive.");
+      query.limit = limit;
+    } else {
+      throw new Error(`Unknown subjects option: ${String(flag)}.`);
+    }
+    index += 1;
+  }
+  if (host === undefined) throw new Error("This command requires --host.");
+  const application = await openApplication(host, environment);
+  try {
+    const page = await application.distilly.list(query);
+    if (asJson) {
+      io.stdout.write(`${JSON.stringify(page, undefined, 2)}\n`);
+      return;
+    }
+    io.stdout.write(`${describeSubjectList(page).join("\n")}\n`);
   } finally {
     await application.close();
   }
@@ -286,6 +481,8 @@ Usage:
   distilly install <subject-id> --host <host>
   distilly uninstall --host <host>
   distilly panel --host <host>
+  distilly subjects --host <host> [--query <text>] [--limit <n>] [--cursor <cursor>] [--json]
+  distilly show <subject-id|display-name> --host <host> [--json]
   distilly harvest <directory> --host <host> --subject <subject-id>|--name <display-name>
                    [--sensitivity private|shareable] [--limit <n>]
   # <host>: codex | claude-code | openclaw | hermes | dsh
@@ -364,8 +561,16 @@ export const runPreviewCli = async (
     await runMcp(host, environment);
     return 0;
   }
+  if (command === "show") {
+    await runShow(args, environment, io);
+    return 0;
+  }
   if (command === "harvest") {
     await runHarvest(args, environment, io);
+    return 0;
+  }
+  if (command === "subjects") {
+    await runSubjects(args, environment, io);
     return 0;
   }
   if (command === "panel") {

--- a/packages/cli/src/show.test.ts
+++ b/packages/cli/src/show.test.ts
@@ -1,10 +1,4 @@
-import type {
-  JobId,
-  Profile,
-  SubjectId,
-  SubjectSummary,
-  VersionId,
-} from "@distilly/protocol";
+import type { JobId, Profile, SubjectId, SubjectSummary, VersionId } from "@distilly/protocol";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/cli/src/show.test.ts
+++ b/packages/cli/src/show.test.ts
@@ -1,0 +1,152 @@
+import type {
+  JobId,
+  Profile,
+  SubjectId,
+  SubjectSummary,
+  VersionId,
+} from "@distilly/protocol";
+import { describe, expect, it } from "vitest";
+
+import {
+  describeAmbiguousSubject,
+  describePendingProfile,
+  describeProfile,
+  describeSubjectList,
+  looksLikeSubjectId,
+} from "./show.js";
+
+const profile = (overrides: Partial<Profile["quality"]> = {}, claims = 0): Profile =>
+  ({
+    subjectId: `subject_${"a".repeat(32)}` as SubjectId,
+    displayName: "Ada Lovelace",
+    versionId: `version_${"b".repeat(64)}` as VersionId,
+    claims: Array.from({ length: claims }, () => ({}) as never),
+    core: {} as Profile["core"],
+    domains: {},
+    rendered: "",
+    quality: {
+      sourceGroupingVersion: "source-groups-v1",
+      activeClaimCount: 3,
+      contestedClaimCount: 0,
+      userAssertedClaimCount: 0,
+      corroboratedClaimCount: 0,
+      sourceGroupCount: 2,
+      diversityEligibleSourceGroupCount: 2,
+      unknownSourceGroupCount: 0,
+      coveredCoreFacets: ["identity", "voice"],
+      uncoveredCoreFacets: ["psyche", "relations", "boundaries", "texture", "timeline"],
+      maturity: "forming",
+      ...overrides,
+    },
+  }) as unknown as Profile;
+
+describe("profile report", () => {
+  it("names the missing facets and what material would cover each one", () => {
+    const report = describeProfile(profile());
+    const text = report.lines.join("\n");
+    expect(report.missingFacets).toEqual([
+      "psyche",
+      "relations",
+      "boundaries",
+      "texture",
+      "timeline",
+    ]);
+    expect(text).toContain("Maturity: forming");
+    expect(text).toContain("Covered core facets: identity, voice");
+    expect(text).toContain("Missing core facets: psyche, relations, boundaries, texture, timeline");
+    expect(text).toContain("psyche: a decision they made");
+    expect(text).toContain("boundaries: something they refused");
+  });
+
+  it("says nothing is missing once every core facet is covered", () => {
+    const report = describeProfile(
+      profile({
+        coveredCoreFacets: [
+          "identity",
+          "voice",
+          "psyche",
+          "relations",
+          "boundaries",
+          "texture",
+          "timeline",
+        ],
+        uncoveredCoreFacets: [],
+        maturity: "stable",
+      }),
+    );
+    expect(report.missingFacets).toEqual([]);
+    expect(report.lines.join("\n")).toContain("Missing core facets: none");
+    expect(report.lines.join("\n")).not.toContain("To cover what is missing");
+  });
+
+  it("warns about contested claims and a single source group", () => {
+    const text = describeProfile(
+      profile({ contestedClaimCount: 2, sourceGroupCount: 1 }),
+    ).lines.join("\n");
+    expect(text).toContain("2 claim(s) are contested");
+    expect(text).toContain("single source group");
+  });
+});
+
+const summary = (name: string, letter: string, withProfile: boolean): SubjectSummary => ({
+  id: `subject_${letter.repeat(32)}` as SubjectId,
+  displayName: name,
+  aliases: [],
+  identityHints: [],
+  space: {
+    id: `space_${letter.repeat(32)}` as SubjectSummary["space"]["id"],
+    displayName: "People",
+    kind: "people",
+  },
+  lifecycle: "active",
+  ...(withProfile ? { currentVersionId: `version_${letter.repeat(64)}` as VersionId } : {}),
+});
+
+describe("subject argument and listing", () => {
+  it("treats a canonical id as an id and a name as a name", () => {
+    expect(looksLikeSubjectId(`subject_${"a".repeat(32)}`)).toBe(true);
+    expect(looksLikeSubjectId("Ada Lovelace")).toBe(false);
+    expect(looksLikeSubjectId(`subject_${"A".repeat(32)}`)).toBe(false);
+    expect(looksLikeSubjectId("subject_short")).toBe(false);
+  });
+
+  it("lists subjects with the id to reuse and whether a profile exists", () => {
+    const lines = describeSubjectList({
+      items: [summary("Ada Lovelace", "a", true), summary("Grace Hopper", "b", false)],
+    });
+    expect(lines[0]).toBe(
+      `Ada Lovelace (subject_${"a".repeat(32)}) — has a profile · people · active`,
+    );
+    expect(lines[1]).toContain("no profile yet");
+    expect(lines.join("\n")).toContain("2 subject(s).");
+  });
+
+  it("says how to create the first subject instead of printing an empty table", () => {
+    const lines = describeSubjectList({ items: [] });
+    expect(lines.join("\n")).toContain("No subjects yet.");
+    expect(lines.join("\n")).toContain("distilly harvest <directory> --host <host> --name");
+  });
+
+  it("reports a harvested person with no committed profile as a normal state", () => {
+    const lines = describePendingProfile(summary("Ada Lovelace", "a", false), {
+      subject: summary("Ada Lovelace", "a", false),
+      generation: 1,
+      pendingJobId: `job_${"c".repeat(32)}` as JobId,
+    });
+    const text = lines.join("\n");
+    expect(text).toContain("No profile yet");
+    expect(text).toContain("waiting for the host to brief and commit it");
+    expect(text).toContain("Panel");
+  });
+
+  it("hands back every candidate when a name is ambiguous", () => {
+    const lines = describeAmbiguousSubject("Ada Lovelace", [
+      summary("Ada Lovelace", "a", true),
+      summary("Ada Lovelace", "b", false),
+    ]);
+    expect(lines[0]).toBe(`2 subjects match "Ada Lovelace":`);
+    expect(lines[1]).toContain(`subject_${"a".repeat(32)}`);
+    expect(lines[2]).toContain(`subject_${"b".repeat(32)}`);
+    expect(lines.join("\n")).toContain("one of those ids instead of the name");
+  });
+});

--- a/packages/cli/src/show.ts
+++ b/packages/cli/src/show.ts
@@ -1,0 +1,184 @@
+import {
+  subjectIdSchema,
+  type AmbiguousSubjectCandidates,
+  type CoreFacetName,
+  type Profile,
+  type SubjectPage,
+  type SubjectStatus,
+  type SubjectSummary,
+} from "@distilly/protocol";
+
+/** What material would let a profile cover one core facet that is still empty. */
+const FACET_GUIDANCE: Readonly<Record<CoreFacetName, string>> = Object.freeze({
+  identity: "something that states who this person is and how they are addressed",
+  voice: "a real conversation excerpt, so the phrasing is quoted rather than described",
+  psyche: "a decision they made, with the reasoning they gave for it",
+  relations: "how they treat someone close, someone new, and someone with authority",
+  boundaries: "something they refused, avoided, or said they would never do",
+  texture: "ordinary detail: habits, objects, places, and times of day",
+  timeline: "dated material that shows how they changed",
+});
+
+/** Facet order used whenever a report lists facets. */
+const FACET_ORDER: readonly CoreFacetName[] = Object.freeze([
+  "identity",
+  "voice",
+  "psyche",
+  "relations",
+  "boundaries",
+  "texture",
+  "timeline",
+]);
+
+/** Rendered, human-readable report of one profile and what it still lacks. */
+export interface ProfileReport {
+  readonly lines: readonly string[];
+  readonly missingFacets: readonly CoreFacetName[];
+}
+
+/**
+ * Renders one profile's maturity, evidence counts, and the material it still needs.
+ *
+ * The engine already computes every number here; this only decides what a person reads and
+ * in which order, so a thin profile says exactly which material would thicken it instead
+ * of leaving the reader to guess.
+ *
+ * @param profile - Current profile projection.
+ * @param status - Optional subject status, so the report can say whether distillation is
+ * queued or waiting for more material.
+ * @returns Stable report lines plus the facets that carry no claim yet.
+ */
+export const describeProfile = (profile: Profile, status?: SubjectStatus): ProfileReport => {
+  const quality = profile.quality;
+  const missing = FACET_ORDER.filter((facet) => quality.uncoveredCoreFacets.includes(facet));
+  const covered = FACET_ORDER.filter((facet) => quality.coveredCoreFacets.includes(facet));
+  const lines = [
+    `${profile.displayName} (${profile.subjectId})`,
+    `Version: ${profile.versionId}`,
+    `Maturity: ${quality.maturity}`,
+    `Claims: ${String(quality.activeClaimCount)} active, ${String(quality.contestedClaimCount)} contested, ${String(quality.userAssertedClaimCount)} user-asserted, ${String(quality.corroboratedClaimCount)} corroborated`,
+    `Sources: ${String(quality.sourceGroupCount)} group(s), ${String(quality.diversityEligibleSourceGroupCount)} eligible for diversity, ${String(quality.unknownSourceGroupCount)} unknown`,
+    `Covered core facets: ${covered.length === 0 ? "none" : covered.join(", ")}`,
+    `Missing core facets: ${missing.length === 0 ? "none" : missing.join(", ")}`,
+  ];
+  if (status !== undefined) {
+    lines.push(
+      status.pendingJobId === undefined
+        ? "Distillation: nothing queued; add material or ask for a redistill."
+        : `Distillation: job ${status.pendingJobId} is waiting to be briefed and committed.`,
+    );
+  }
+  if (missing.length > 0) {
+    lines.push("", "To cover what is missing, add material like:");
+    for (const facet of missing) lines.push(`  ${facet}: ${FACET_GUIDANCE[facet]}`);
+  }
+  if (quality.contestedClaimCount > 0) {
+    lines.push(
+      "",
+      `${String(quality.contestedClaimCount)} claim(s) are contested; review them before relying on this profile.`,
+    );
+  }
+  if (quality.sourceGroupCount === 1) {
+    lines.push("", "Everything comes from a single source group, so nothing is corroborated yet.");
+  }
+  return { lines, missingFacets: missing };
+};
+
+/**
+ * Renders the state of a subject that has material but no committed profile yet.
+ *
+ * A freshly harvested person is the most common state in the one-shot flow, so it must read
+ * as "nothing is wrong, the host still has to distill this" rather than as an engine error.
+ *
+ * @param subject - Resolved subject summary.
+ * @param status - Current subject status, including any queued distillation job.
+ * @returns Stable report lines.
+ */
+export const describePendingProfile = (
+  subject: SubjectSummary,
+  status?: SubjectStatus,
+): readonly string[] => {
+  const lines = [
+    `${subject.displayName} (${subject.id})`,
+    "No profile yet: material is stored, but no distillation has been committed.",
+  ];
+  if (status?.pendingJobId !== undefined) {
+    lines.push(
+      `Distillation: job ${status.pendingJobId} is waiting for the host to brief and commit it.`,
+    );
+  } else if (status !== undefined) {
+    lines.push("Distillation: nothing queued; add material or ask for a redistill.");
+  }
+  lines.push(
+    "",
+    "Open the host that has Distilly installed and ask it to distill this person, or review it in the Panel.",
+  );
+  return lines;
+};
+
+/**
+ * Reports whether a command argument is a subject id rather than a name to look up.
+ *
+ * A person types a name; the engine addresses a SubjectId. Commands accept either, so this
+ * is the single place that decides which one the argument is, using the protocol's own id
+ * pattern instead of a second guess.
+ *
+ * @param value - Raw command argument.
+ * @returns True when the argument is already a canonical subject id.
+ */
+export const looksLikeSubjectId = (value: string): boolean =>
+  subjectIdSchema.safeParse(value).success;
+
+/**
+ * Renders one subject as a single line a person can copy from.
+ *
+ * @param subject - Subject summary from the engine.
+ * @returns One stable line naming the person, the id to reuse, and what already exists.
+ */
+export const describeSubject = (subject: SubjectSummary): string => {
+  const profile = subject.currentVersionId === undefined ? "no profile yet" : "has a profile";
+  return `${subject.displayName} (${subject.id}) — ${profile} · ${subject.space.kind} · ${subject.lifecycle}`;
+};
+
+/**
+ * Renders a subject listing, including what to run when nothing exists yet.
+ *
+ * @param page - One page of subjects in canonical order.
+ * @returns Stable report lines.
+ */
+export const describeSubjectList = (page: SubjectPage): readonly string[] => {
+  if (page.items.length === 0) {
+    return [
+      "No subjects yet.",
+      "Create one from a directory of your own files: distilly harvest <directory> --host <host> --name <display-name>",
+    ];
+  }
+  const lines = page.items.map((subject) => describeSubject(subject));
+  lines.push(
+    "",
+    page.nextCursor === undefined
+      ? `${String(page.items.length)} subject(s).`
+      : `${String(page.items.length)} subject(s); more remain, repeat with --cursor ${page.nextCursor}.`,
+  );
+  return lines;
+};
+
+/**
+ * Renders the candidates behind an ambiguous name so the caller can choose one.
+ *
+ * Resolution refuses to guess between people with the same name, so the report must hand
+ * back every candidate id and the exact command that picks one.
+ *
+ * @param query - Name the caller asked for.
+ * @param candidates - Two or more subjects the engine matched.
+ * @returns Stable report lines.
+ */
+export const describeAmbiguousSubject = (
+  query: string,
+  candidates: AmbiguousSubjectCandidates,
+): readonly string[] => [
+  `${String(candidates.length)} subjects match "${query}":`,
+  ...candidates.map((candidate) => `  ${describeSubject(candidate)}`),
+  "",
+  `Repeat the command with one of those ids instead of the name.`,
+];

--- a/packages/cli/src/subject-errors.test.ts
+++ b/packages/cli/src/subject-errors.test.ts
@@ -1,0 +1,58 @@
+import { DistillyError, type SubjectSummary } from "@distilly/protocol";
+import { describe, expect, it } from "vitest";
+
+import { ambiguousCandidates, reusableSubject } from "./subject-errors.js";
+
+const summary = (letter: string): SubjectSummary => ({
+  id: `subject_${letter.repeat(32)}` as SubjectSummary["id"],
+  displayName: "Ada Lovelace",
+  aliases: [],
+  identityHints: [],
+  space: {
+    id: `space_${letter.repeat(32)}` as SubjectSummary["space"]["id"],
+    displayName: "People",
+    kind: "people",
+  },
+  lifecycle: "active",
+});
+
+describe("subject errors", () => {
+  it("reuses the single subject a duplicate create reported", () => {
+    const subject = summary("a");
+    const error = new DistillyError({
+      code: "already_exists",
+      message: "A matching subject already exists.",
+      retryable: false,
+      subjectResolution: { kind: "found", subject },
+    });
+    expect(reusableSubject(error)?.id).toBe(subject.id);
+    expect(ambiguousCandidates(error)).toBeUndefined();
+  });
+
+  it("hands back every candidate behind an ambiguous name", () => {
+    const candidates = [summary("a"), summary("b")] as const;
+    const error = new DistillyError({
+      code: "ambiguous_subject",
+      message: "More than one subject matches.",
+      retryable: false,
+      subjectResolution: { kind: "ambiguous", candidates },
+    });
+    expect(ambiguousCandidates(error)?.map((candidate) => candidate.id)).toEqual([
+      candidates[0].id,
+      candidates[1].id,
+    ]);
+    expect(reusableSubject(error)).toBeUndefined();
+  });
+
+  it("ignores unrelated failures and plain errors", () => {
+    const missing = new DistillyError({
+      code: "not_found",
+      message: "No such job.",
+      retryable: false,
+    });
+    expect(reusableSubject(missing)).toBeUndefined();
+    expect(ambiguousCandidates(missing)).toBeUndefined();
+    expect(reusableSubject(new Error("A matching subject already exists."))).toBeUndefined();
+    expect(ambiguousCandidates(undefined)).toBeUndefined();
+  });
+});

--- a/packages/cli/src/subject-errors.ts
+++ b/packages/cli/src/subject-errors.ts
@@ -1,0 +1,34 @@
+import { DistillyError, type SubjectSummary } from "@distilly/protocol";
+
+/** The two candidates (or more) an ambiguous subject name produced. */
+export type SubjectCandidates = readonly [SubjectSummary, SubjectSummary, ...SubjectSummary[]];
+
+/**
+ * Reads the subject the engine matched when a create request collides with an existing name.
+ *
+ * The engine refuses to merge people silently, so it answers a duplicate create with the one
+ * subject it matched. Reusing it is what makes "harvest this folder for Ada" repeatable
+ * instead of a hard failure on the second run.
+ *
+ * @param error - Error thrown by an ingest call.
+ * @returns The matched subject, or undefined when this is a different failure.
+ */
+export const reusableSubject = (error: unknown): SubjectSummary | undefined => {
+  if (!(error instanceof DistillyError)) return undefined;
+  if (error.code !== "already_exists") return undefined;
+  const resolution = error.subjectResolution;
+  return resolution?.kind === "found" ? resolution.subject : undefined;
+};
+
+/**
+ * Reads the candidates behind an ambiguous subject name.
+ *
+ * @param error - Error thrown by an ingest call.
+ * @returns The candidate list, or undefined when this is a different failure.
+ */
+export const ambiguousCandidates = (error: unknown): SubjectCandidates | undefined => {
+  if (!(error instanceof DistillyError)) return undefined;
+  if (error.code !== "ambiguous_subject") return undefined;
+  const resolution = error.subjectResolution;
+  return resolution?.kind === "ambiguous" ? resolution.candidates : undefined;
+};

--- a/packages/runtime/src/preview.test.ts
+++ b/packages/runtime/src/preview.test.ts
@@ -612,3 +612,117 @@ describe("Developer Preview LocalRuntime", () => {
     });
   });
 });
+
+describe("local record budget", () => {
+  it("splits an oversized text and refuses a selection that expands past the wire record limit", async () => {
+    const root = await temporaryRoot();
+    const inputRoot = await temporaryRoot();
+    const paths: string[] = [];
+    // The JSON parser pretty-prints, so a 500 KB file becomes more than one material record
+    // while staying under the per-file material limit that would send it alone.
+    const compact = JSON.stringify({
+      items: Array.from({ length: 9_000 }, (_, index) => ({
+        id: index,
+        name: `item-${String(index)}`,
+        tags: ["alpha", "beta", "gamma"],
+        nested: { a: 1, b: "two", c: [1, 2, 3] },
+      })),
+    });
+    expect(Buffer.byteLength(compact)).toBeLessThan(1_048_576);
+    expect(Buffer.byteLength(JSON.stringify(JSON.parse(compact), null, 2))).toBeGreaterThan(
+      1_048_576,
+    );
+    const jsonPath = join(inputRoot, "export.json");
+    await writeFile(jsonPath, compact);
+    paths.push(jsonPath);
+    for (let index = 0; index < 31; index += 1) {
+      const path = join(inputRoot, `note-${String(index)}.md`);
+      await writeFile(path, `Note ${String(index)} records one ordinary observation.\n`);
+      paths.push(path);
+    }
+
+    const runtime = await open(root);
+    const client = await connect(runtime, "record-budget");
+    const failure = await client
+      .call(
+        "materials.ingestFiles",
+        {
+          subject: { kind: "create" as const, input: { displayName: "Budget", identityHints: [] } },
+          paths,
+          enqueue: "now" as const,
+        },
+        { requestId: request() },
+      )
+      .then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+    expect(failure).toBeInstanceOf(DistillyError);
+    expect((failure as DistillyError).code).toBe("invalid_input");
+    expect((failure as DistillyError).details?.["reason"]).toBe("record_budget_exceeded");
+
+    // The same selection succeeds when the expanding file travels alone, which is what the
+    // harvest command falls back to.
+    const small = await client.call(
+      "materials.ingestFiles",
+      {
+        subject: { kind: "create" as const, input: { displayName: "Budget", identityHints: [] } },
+        paths: paths.slice(1),
+        enqueue: "now" as const,
+      },
+      { requestId: request() },
+    );
+    expect(small.items).toHaveLength(31);
+    const alone = await client.call(
+      "materials.ingestFiles",
+      {
+        subject: { kind: "existing" as const, subjectId: small.subject.id },
+        paths: [jsonPath],
+        enqueue: "now" as const,
+      },
+      { requestId: request() },
+    );
+    expect(alone.items.length).toBeGreaterThan(1);
+    expect(alone.items.map((item) => item.pathLabel)).toContain("export.json [part 1 of 3]");
+  });
+});
+
+describe("split reassembly through the engine", () => {
+  it("briefs every part of a split file and reproduces the parsed text byte for byte", async () => {
+    const root = await temporaryRoot();
+    const inputRoot = await temporaryRoot();
+    const path = join(inputRoot, "mixed.md");
+    // Astral characters and line boundaries both sit on part seams: 2.5 MiB of 4-byte code
+    // points with a newline every 32 characters.
+    const line = `${"😀".repeat(31)}\n`;
+    const original = line.repeat(Math.ceil((2.5 * 1_048_576) / Buffer.byteLength(line)));
+    await writeFile(path, original);
+
+    const runtime = await open(root);
+    // The direct-user capacity is wide enough to carry the whole briefing, so this proves the
+    // stored parts, not the splitter alone.
+    const client = await connect(runtime, "split-reassembly");
+    const result = await client.call(
+      "materials.ingestFiles",
+      {
+        subject: {
+          kind: "create" as const,
+          input: { displayName: "Reassembly", identityHints: [] },
+        },
+        paths: [path],
+        enqueue: "now" as const,
+      },
+      { requestId: request() },
+    );
+    expect(result.items.length).toBeGreaterThan(1);
+    if (result.job === undefined) throw new Error("Expected an enqueued job.");
+    const briefing = await client.call(
+      "distill.brief",
+      { jobId: result.job.id },
+      { requestId: request() },
+    );
+    const joined = briefing.materials.map((entry) => entry.content).join("");
+    expect(joined).toBe(original);
+    expect(joined).not.toContain("\uFFFD");
+  });
+});

--- a/packages/runtime/src/preview.ts
+++ b/packages/runtime/src/preview.ts
@@ -2,6 +2,8 @@ import { lstat, readFile } from "node:fs/promises";
 import { basename, extname } from "node:path";
 
 import { createBuiltinParserRegistry } from "@distilly/adapters";
+
+import { splitParsedText } from "./split-parsed-text.js";
 import type { ParsedMaterial } from "@distilly/adapters";
 import type { HostBinding, HostContext, HostInjector } from "@distilly/bindings";
 import {
@@ -126,51 +128,6 @@ const parserWarning = (error: unknown): string => {
 const assertNoSymlinkFile = async (path: string): Promise<void> => {
   const metadata = await lstat(path);
   if (metadata.isSymbolicLink()) throw new Error("symlinked local path");
-};
-
-/**
- * Splits rendered material text into parts that each fit the local material limit.
- *
- * Text is cut at line boundaries so a part never begins mid-line, except when one line is
- * itself larger than the limit, which is then cut by characters. Deterministic: the same
- * text always yields the same parts.
- *
- * @param text - Rendered material text.
- * @param maximumBytes - Largest UTF-8 byte length one part may have.
- * @returns One or more part texts, in order.
- */
-const splitParsedText = (text: string, maximumBytes: number): readonly string[] => {
-  const encoder = new TextEncoder();
-  const parts: string[] = [];
-  let current: string[] = [];
-  let currentBytes = 0;
-  const flush = (): void => {
-    if (current.length === 0) return;
-    parts.push(current.join("\n"));
-    current = [];
-    currentBytes = 0;
-  };
-  for (const line of text.split("\n")) {
-    let remaining = line;
-    for (;;) {
-      const lineBytes = encoder.encode(remaining).byteLength;
-      if (lineBytes <= maximumBytes) break;
-      // One line exceeds a whole part: cut it by characters at the byte boundary.
-      let cut = remaining.length;
-      while (cut > 1 && encoder.encode(remaining.slice(0, cut)).byteLength > maximumBytes) {
-        cut -= 1;
-      }
-      flush();
-      parts.push(remaining.slice(0, cut));
-      remaining = remaining.slice(cut);
-    }
-    const lineBytes = encoder.encode(remaining).byteLength + 1;
-    if (currentBytes + lineBytes > maximumBytes) flush();
-    current.push(remaining);
-    currentBytes += lineBytes;
-  }
-  flush();
-  return parts;
 };
 
 /** Largest rendered text the loader accepts before it must split into parts. */
@@ -314,7 +271,24 @@ const createLocalFileLoader = () => {
           };
         }),
       );
-      return perPath.flat();
+      const records = perPath.flat();
+      // One selected file can expand into several records when its parsed text is split, so
+      // the file count is not the record count. Refuse here, with a reason the caller can act
+      // on, instead of letting the engine see more records than the wire limit allows.
+      if (records.length > WIRE_LIMITS.ingestMaterials) {
+        throw new DistillyError({
+          code: "invalid_input",
+          message: `This selection expands to ${String(records.length)} material records, more than the ${String(WIRE_LIMITS.ingestMaterials)} one ingest call carries.`,
+          retryable: false,
+          remediation: "Ingest fewer files at once, starting with the largest ones.",
+          details: {
+            reason: "record_budget_exceeded",
+            records: records.length,
+            maximumRecords: WIRE_LIMITS.ingestMaterials,
+          },
+        });
+      }
+      return records;
     },
   };
 };

--- a/packages/runtime/src/split-parsed-text.test.ts
+++ b/packages/runtime/src/split-parsed-text.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { splitParsedText } from "./split-parsed-text.js";
+
+const encoder = new TextEncoder();
+const bytes = (text: string): number => encoder.encode(text).byteLength;
+const maximumBytes = 1_048_576;
+
+const expectReassembles = (text: string, parts: readonly string[]): void => {
+  expect(parts.join("")).toBe(text);
+  for (const part of parts) {
+    expect(part.length).toBeGreaterThan(0);
+    expect(bytes(part)).toBeLessThanOrEqual(maximumBytes);
+  }
+};
+
+const loneSurrogates = (text: string): number => {
+  let count = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    if (code < 0xd800 || code > 0xdfff) continue;
+    if (code <= 0xdbff && index + 1 < text.length) {
+      const next = text.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        index += 1;
+        continue;
+      }
+    }
+    count += 1;
+  }
+  return count;
+};
+
+describe("parsed text splitting", () => {
+  it("keeps every part within the limit and loses nothing for a size sweep", () => {
+    const line = `${"a".repeat(63)}\n`;
+    for (const size of [
+      maximumBytes - 1,
+      maximumBytes,
+      maximumBytes + 1,
+      2 * maximumBytes,
+      3 * maximumBytes,
+      2.5 * maximumBytes,
+    ]) {
+      const text = line.repeat(Math.ceil(size / line.length)).slice(0, size);
+      const parts = splitParsedText(text, maximumBytes);
+      expectReassembles(text, parts);
+    }
+  });
+
+  it("does not emit an empty trailing part for an exact multiple of the limit", () => {
+    // 64-byte lines: 1 MiB is an exact multiple of 64, which previously produced a third
+    // empty part and made the whole ingest call fail its minimum-length check.
+    const line = `${"a".repeat(63)}\n`;
+    const text = line.repeat(maximumBytes / line.length);
+    expect(bytes(text)).toBe(maximumBytes);
+    const parts = splitParsedText(text, maximumBytes);
+    expect(parts).toEqual([text]);
+    expect(parts.some((part) => part.length === 0)).toBe(false);
+
+    const doubled = text.repeat(2);
+    const doubledParts = splitParsedText(doubled, maximumBytes);
+    expect(doubledParts).toHaveLength(2);
+    expectReassembles(doubled, doubledParts);
+  });
+
+  it("never cuts between a high and a low surrogate", () => {
+    const text = `a${"😀".repeat(262_150)}\n`;
+    const parts = splitParsedText(text, maximumBytes);
+    expectReassembles(text, parts);
+    for (const part of parts) expect(loneSurrogates(part)).toBe(0);
+    // Round-tripping through UTF-8 must not introduce a replacement character.
+    expect(parts.map((part) => new TextDecoder().decode(encoder.encode(part))).join("")).toBe(text);
+    expect(parts.join("")).not.toContain("\uFFFD");
+  });
+
+  it("cuts a single over-long line quickly instead of rescanning every prefix", () => {
+    const text = "x".repeat(3 * maximumBytes);
+    const started = Date.now();
+    const parts = splitParsedText(text, maximumBytes);
+    const elapsed = Date.now() - started;
+    expect(parts).toHaveLength(3);
+    expect(parts.every((part) => bytes(part) === maximumBytes)).toBe(true);
+    expectReassembles(text, parts);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  it("does not start a part with a combining mark", () => {
+    // 1 MiB of two-byte code points, then a base letter with a combining acute accent.
+    const text = `${"\u00e9".repeat(maximumBytes / 2)}e\u0301 tail`;
+    const parts = splitParsedText(text, maximumBytes);
+    expectReassembles(text, parts);
+    for (const part of parts) {
+      const first = part.codePointAt(0) ?? 0;
+      const isCombining = /^\p{M}$/u.test(String.fromCodePoint(first));
+      expect(isCombining).toBe(false);
+    }
+  });
+
+  it("still splits correctly when the limit is only a few bytes", () => {
+    const text = "ab😀cd\u0301ef\ngh";
+    const parts = splitParsedText(text, 4);
+    for (const part of parts) expect(bytes(part)).toBeLessThanOrEqual(4);
+    expect(parts.join("")).toBe(text);
+  });
+
+  it("returns no parts for empty text", () => {
+    expect(splitParsedText("", maximumBytes)).toEqual([]);
+  });
+
+  it("is deterministic for the same input", () => {
+    const text = `${"😀 line\n".repeat(90_000)}tail`;
+    expect(splitParsedText(text, maximumBytes)).toEqual(splitParsedText(text, maximumBytes));
+  });
+});

--- a/packages/runtime/src/split-parsed-text.ts
+++ b/packages/runtime/src/split-parsed-text.ts
@@ -1,0 +1,122 @@
+/**
+ * Splits one oversized parsed text into parts that each fit the local material byte limit.
+ *
+ * The split is byte-exact and deterministic: the parts are consecutive slices of the source,
+ * so joining them with an empty string reproduces the source exactly, no byte is added or
+ * dropped, and no part is empty. Cuts prefer a line boundary; only a single line that cannot
+ * fit in one part is cut inside the line, at a Unicode code point boundary, never between a
+ * high and a low surrogate and never immediately before a combining mark.
+ *
+ * @param text - Rendered material text.
+ * @param maximumBytes - Largest UTF-8 byte length one part may have.
+ * @returns One or more part texts, in order; no parts for empty text.
+ */
+export const splitParsedText = (text: string, maximumBytes: number): readonly string[] => {
+  if (maximumBytes < 4) throw new Error("A part must be able to hold one code point.");
+  const parts: string[] = [];
+  let partStart = 0;
+  let partBytes = 0;
+  let cursor = 0;
+  const pushPart = (end: number): void => {
+    parts.push(text.slice(partStart, end));
+    partStart = end;
+    partBytes = 0;
+  };
+  while (cursor < text.length) {
+    const newline = text.indexOf("\n", cursor);
+    // A line keeps its own newline, so a cut after it loses nothing.
+    const lineEnd = newline === -1 ? text.length : newline + 1;
+    const lineBytes = utf8BytesIn(text, cursor, lineEnd);
+    if (partBytes + lineBytes <= maximumBytes) {
+      partBytes += lineBytes;
+      cursor = lineEnd;
+      continue;
+    }
+    if (lineBytes > maximumBytes) {
+      // One line is larger than a whole part: fill the rest of this part by code point.
+      let end = cursor;
+      let bytes = partBytes;
+      while (end < lineEnd) {
+        const codePoint = text.codePointAt(end) ?? 0;
+        const width = utf8Width(codePoint);
+        if (bytes + width > maximumBytes) break;
+        bytes += width;
+        end += codePoint > 0xffff ? 2 : 1;
+      }
+      // A part must not begin with a combining mark, or the mark renders detached.
+      while (end > cursor && end < lineEnd) {
+        const next = text.codePointAt(end) ?? 0;
+        if (!COMBINING_MARK.test(String.fromCodePoint(next))) break;
+        const previousStart = previousCodePointStart(text, end, cursor);
+        bytes -= utf8Width(text.codePointAt(previousStart) ?? 0);
+        end = previousStart;
+      }
+      if (end > cursor) {
+        cursor = end;
+        partBytes = bytes;
+      }
+      // A part that is already full is flushed and the line continues in the next part.
+      if (partBytes > 0) pushPart(cursor);
+      continue;
+    }
+    // The line fits in an empty part, so this part ends here and the line starts the next one.
+    pushPart(cursor);
+  }
+  if (partBytes > 0) parts.push(text.slice(partStart));
+  return parts;
+};
+
+/** Matches one combining mark, which must not be the first code point of a part. */
+const COMBINING_MARK = /^\p{M}$/u;
+
+/**
+ * Measures the UTF-8 byte width of one code point.
+ *
+ * A lone surrogate counts as its three-byte replacement character, which is what TextEncoder
+ * writes for it.
+ *
+ * @param codePoint - Code point value from the source text.
+ * @returns UTF-8 byte width, between one and four.
+ */
+const utf8Width = (codePoint: number): number => {
+  if (codePoint < 0x80) return 1;
+  if (codePoint < 0x800) return 2;
+  if (codePoint < 0x10000) return 3;
+  return 4;
+};
+
+/**
+ * Counts the UTF-8 bytes of a slice without allocating a buffer.
+ *
+ * @param text - Source text.
+ * @param start - First UTF-16 index of the slice.
+ * @param end - Exclusive end of the slice.
+ * @returns Exact UTF-8 byte length, matching TextEncoder.
+ */
+const utf8BytesIn = (text: string, start: number, end: number): number => {
+  let bytes = 0;
+  let index = start;
+  while (index < end) {
+    const codePoint = text.codePointAt(index) ?? 0;
+    bytes += utf8Width(codePoint);
+    index += codePoint > 0xffff ? 2 : 1;
+  }
+  return bytes;
+};
+
+/**
+ * Finds the start of the code point that ends at one index.
+ *
+ * @param text - Source text.
+ * @param index - Exclusive end of the code point.
+ * @param floor - Lowest index the search may return.
+ * @returns UTF-16 index where that code point starts.
+ */
+const previousCodePointStart = (text: string, index: number, floor: number): number => {
+  const previous = text.charCodeAt(index - 1);
+  if (previous >= 0xdc00 && previous <= 0xdfff && index - 2 >= floor) {
+    const high = text.charCodeAt(index - 2);
+    if (high >= 0xd800 && high <= 0xdbff) return index - 2;
+  }
+  return index - 1;
+};


### PR DESCRIPTION
## What
feat(cli): resolve people by name, show profile gaps; byte-exact file splitting

## Commits
- feat(cli): resolve people by name and show a profile with its gaps
- fix(runtime): split oversized text into byte-exact code-point parts

## Stack
Stacked on `pr/06-hermes-and-split-v1`; the whole series ends at `distilly-work` (`0bd924e`).

## Verification
Every feature carries an author report and an independent audit in the delivery evidence folder (`host-verification/`), including screenshots and the audit verdict that drove the fixes. Gates on the top of the stack: format, lint, docs, release check, and 1163 tests.

## Real hosts
Codex, Claude Code 2.1.268, OpenClaw 2026.9.2, Hermes v0.19.0, and DSH 0.1.5-rc.1 were each exercised end to end (install, host-visible confirmation, exactly five MCP tools, person Skill install/remove, uninstall). Capacity fixtures are recorded for Codex 0.146.0, OpenClaw 2026.3.24, and Hermes v0.9.0; newer host versions run on the labelled conservative floor.

## Evidence
Author reports and screenshots (delivery evidence folder `host-verification/`):
- f4-f7-show-subject-resolution-REPORT.md, f4-subject-resolution.png
- f3-split-fixes-REPORT.md, f3-split-fixes.png

Independent audit reports:
- round11-subject-resolution-VERIFY.md, round10-VERIFY.md, round11-split-VERIFY.md