### PR TITLE
feat: chat-export transcripts, idempotent harvest, linear splitter

### DIFF
--- a/packages/adapters/src/builtin-parsers.ts
+++ b/packages/adapters/src/builtin-parsers.ts
@@ -1,5 +1,6 @@
 import { DistillyError } from "@distilly/protocol";
 
+import { detectChatExport, renderChatExport } from "./chat-export-parser.js";
 import { parseEmailMessages } from "./email-parser.js";
 
 import type {
@@ -154,15 +155,79 @@ const stableJson = (value: unknown): unknown => {
   );
 };
 
-const parseJson = (text: string): string => {
+/**
+ * Parses one JSON file, rendering a recognized chat export as a conversation transcript.
+ *
+ * A chat export is the most useful JSON a person owns: it carries their own words and the
+ * other side's replies. Detection is structural, so a renamed export still works, and any
+ * other JSON document keeps the previous stable pretty-printed rendering.
+ *
+ * @param text - Decoded UTF-8 file text.
+ * @returns Parsed value or detected export plus the parser's rendering decision.
+ */
+const readJson = (
+  text: string,
+): { readonly value: unknown; readonly kind?: ReturnType<typeof detectChatExport> } => {
   let value: unknown;
   try {
     value = JSON.parse(text);
   } catch {
     throw invalidInput("JSON material must contain one valid JSON value.", "bytes");
   }
-  return JSON.stringify(stableJson(value), null, 2);
+  const kind = detectChatExport(value);
+  return { value, ...(kind === undefined ? {} : { kind }) };
 };
+
+const jsonParser = (id: string, mediaType: string): MaterialParser => ({
+  id,
+  accepts: Object.freeze([mediaType]),
+  parse(input, context) {
+    return Promise.resolve().then(() => {
+      if (input.mediaType !== mediaType) {
+        throw invalidInput(`Parser ${id} does not accept ${input.mediaType}.`, "mediaType");
+      }
+      const parsed = readJson(decodeUtf8(input.bytes));
+      if (parsed.kind === undefined) {
+        return draft(
+          input,
+          JSON.stringify(stableJson(parsed.value), null, 2),
+          "document",
+          { method: "document_text", producer: id },
+          context.maximumOutputBytes,
+        );
+      }
+      const transcript = renderChatExport(parsed.kind, parsed.value, {
+        maximumOutputBytes: context.maximumOutputBytes,
+      });
+      if (transcript.messageCount === 0) {
+        return {
+          warnings: [
+            `The file looks like a ${transcript.kind} export but contained no message text; it was stored as an unparsed file.`,
+          ],
+        };
+      }
+      const result = draft(
+        input,
+        transcript.content,
+        "transcript",
+        { method: "document_text", producer: `${id}:${transcript.kind}` },
+        context.maximumOutputBytes,
+      );
+      const material =
+        result.material === undefined
+          ? undefined
+          : { ...result.material, participants: transcript.participants };
+      const warnings = [
+        ...transcript.warnings,
+        `Rendered ${String(transcript.messageCount)} message(s) from ${String(transcript.conversationCount)} conversation(s).`,
+      ];
+      return {
+        ...(material === undefined ? {} : { material }),
+        warnings,
+      };
+    });
+  },
+});
 
 const TIMING_LINE =
   /^\s*(?:\d{1,2}:)?\d{2}:\d{2}[.,]\d{3}\s+-->\s+(?:\d{1,2}:)?\d{2}:\d{2}[.,]\d{3}(?:\s+.*)?$/u;
@@ -225,7 +290,7 @@ export const createBuiltinParserRegistry = (): ParserRegistry => {
   for (const parser of [
     emailParser("distilly-eml", "message/rfc822", false),
     emailParser("distilly-mbox", "application/mbox", true),
-    documentParser("distilly-json", "application/json", parseJson),
+    jsonParser("distilly-json", "application/json"),
     subtitleParser("distilly-srt", "application/x-subrip"),
     documentParser("distilly-markdown", "text/markdown", (text) => text),
     documentParser("distilly-text", "text/plain", (text) => text),

--- a/packages/adapters/src/chat-export-parser.test.ts
+++ b/packages/adapters/src/chat-export-parser.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+
+import { createBuiltinParserRegistry } from "./builtin-parsers.js";
+import { detectChatExport, renderChatExport } from "./chat-export-parser.js";
+
+import type { ParseContext, RawMaterial } from "./contracts.js";
+import type { IsoDateTime, RequestId, SubjectId } from "@distilly/protocol";
+
+const context: ParseContext = {
+  subjectId: `subject_${"a".repeat(32)}` as SubjectId,
+  requestId: `req_${"b".repeat(32)}` as RequestId,
+  maximumOutputBytes: 32 * 1024 * 1024,
+};
+
+const raw = (value: unknown, name = "export.json"): RawMaterial => ({
+  clientRef: name,
+  mediaType: "application/json",
+  bytes: new TextEncoder().encode(JSON.stringify(value)),
+  source: {
+    medium: "document",
+    access: "private",
+    capturedAt: "2026-09-11T00:00:00.000Z" as IsoDateTime,
+    title: name,
+  },
+});
+
+const chatGptExport = [
+  {
+    title: "Rollback review",
+    create_time: 1_772_000_000.5,
+    current_node: "n3",
+    mapping: {
+      n1: {
+        id: "n1",
+        parent: null,
+        message: {
+          author: { role: "user" },
+          create_time: 1_772_000_000.5,
+          content: { content_type: "text", parts: ["What breaks first if we ship this?"] },
+        },
+      },
+      n2: {
+        id: "n2",
+        parent: "n1",
+        message: {
+          author: { role: "assistant" },
+          create_time: 1_772_000_001.5,
+          content: {
+            content_type: "text",
+            parts: ["The cache key.\nThen the retry budget."],
+          },
+        },
+      },
+      n2branch: {
+        id: "n2branch",
+        parent: "n1",
+        message: {
+          author: { role: "assistant" },
+          create_time: 1_772_000_002.5,
+          content: { content_type: "text", parts: ["THIS BRANCH WAS NOT CHOSEN"] },
+        },
+      },
+      n3: {
+        id: "n3",
+        parent: "n2",
+        message: {
+          author: { role: "user" },
+          create_time: 1_772_000_003.5,
+          content: {
+            content_type: "user_editable_context",
+            user_profile: "Ada ships behind a rollback plan.",
+            user_instructions: "Answer with the failure mode first.",
+          },
+        },
+      },
+      n4: {
+        id: "n4",
+        parent: "n3",
+        message: {
+          author: { role: "assistant" },
+          create_time: 1_772_000_004.5,
+          content: { content_type: "model_editable_context", parts: ["assistant bookkeeping"] },
+        },
+      },
+    },
+  },
+];
+
+const claudeExport = [
+  {
+    uuid: "c1",
+    name: "Compiler debugging",
+    created_at: "2026-03-05T10:00:00.000Z",
+    chat_messages: [
+      { sender: "human", created_at: "2026-03-05T10:00:01.000Z", text: "Read the listing." },
+      {
+        sender: "assistant",
+        created_at: "2026-03-05T10:00:02.000Z",
+        text: "Line 42 shifts early.",
+      },
+      { sender: "assistant", text: "" },
+    ],
+  },
+];
+
+const telegramExport = {
+  name: "Ada and Grace",
+  type: "personal_chat",
+  messages: [
+    { type: "message", from: "Ada", date: "2026-03-05T10:00:00+01:00", text: "Ship it." },
+    {
+      type: "message",
+      from: "Grace",
+      date: "2026-03-05T10:00:05+01:00",
+      text: [
+        { type: "bold", text: "No" },
+        { type: "plain", text: ", not yet." },
+      ],
+    },
+    { type: "service", from: "Ada", date: "2026-03-05T10:00:06+01:00", text: "joined" },
+  ],
+};
+
+const slackExport = {
+  channel: "C0123",
+  name: "design",
+  messages: [
+    { type: "message", user: "U1", ts: "1772000000.000100", text: "rollback &amp; retry" },
+    { type: "message", username: "grace", ts: "1772000060.000200", text: "agreed" },
+    { type: "message", subtype: "channel_join", user: "U2", ts: "1772000120.000300" },
+  ],
+};
+
+const discordExport = {
+  channel: { id: "99", name: "incidents" },
+  messages: [
+    {
+      author: { id: "1", name: "ada", nickname: "Ada" },
+      timestamp: "2026-03-05T10:00:00+00:00",
+      content: "The failure mode was a cache key.",
+      attachments: [{ url: "https://example.test/a.png" }],
+    },
+    { author: { id: "2", name: "grace" }, timestamp: "2026-03-05T10:00:30+00:00", content: "" },
+  ],
+};
+
+describe("chat export detection", () => {
+  it("recognizes each supported export structurally", () => {
+    expect(detectChatExport(chatGptExport)).toBe("chatgpt");
+    expect(detectChatExport(claudeExport)).toBe("claude");
+    expect(detectChatExport(telegramExport)).toBe("telegram");
+    expect(detectChatExport(slackExport)).toBe("slack");
+    expect(detectChatExport(discordExport)).toBe("discord");
+  });
+
+  it("leaves any other JSON document alone", () => {
+    expect(detectChatExport({ items: [{ id: 1 }] })).toBeUndefined();
+    expect(detectChatExport([{ id: 1, name: "x" }])).toBeUndefined();
+    expect(detectChatExport({ messages: [{ text: "no speaker" }] })).toBeUndefined();
+    expect(detectChatExport("string")).toBeUndefined();
+    expect(detectChatExport(undefined)).toBeUndefined();
+  });
+});
+
+describe("chat export rendering", () => {
+  it("renders only the current ChatGPT path and keeps message text verbatim", () => {
+    const transcript = renderChatExport("chatgpt", chatGptExport, {
+      maximumOutputBytes: 1_000_000,
+    });
+    expect(transcript.content).toContain("# ChatGPT conversation export");
+    expect(transcript.content).toContain("## Rollback review (2026-02-25T06:13:20.500Z)");
+    expect(transcript.content).toContain(
+      "[2026-02-25T06:13:20.500Z] user: What breaks first if we ship this?",
+    );
+    expect(transcript.content).toContain("assistant: The cache key.\nThen the retry budget.");
+    expect(transcript.content).toContain("user (profile): Ada ships behind a rollback plan.");
+    expect(transcript.content).toContain("Answer with the failure mode first.");
+    expect(transcript.content).not.toContain("THIS BRANCH WAS NOT CHOSEN");
+    expect(transcript.content).not.toContain("assistant bookkeeping");
+    expect(transcript.participants).toEqual(["user", "assistant", "user (profile)"]);
+    expect(transcript.messageCount).toBe(3);
+    expect(transcript.warnings.join(" ")).toContain("outside each conversation's current path");
+  });
+
+  it("renders Claude, Telegram, Slack, and Discord exports with normalized times", () => {
+    const claude = renderChatExport("claude", claudeExport, { maximumOutputBytes: 1_000_000 });
+    expect(claude.content).toContain("[2026-03-05T10:00:01.000Z] human: Read the listing.");
+    expect(claude.warnings.join(" ")).toContain("1 message(s) carried no text");
+
+    const telegram = renderChatExport("telegram", telegramExport, {
+      maximumOutputBytes: 1_000_000,
+    });
+    expect(telegram.content).toContain("[2026-03-05T09:00:05.000Z] Grace: No, not yet.");
+    expect(telegram.content).toContain("[2026-03-05T09:00:00.000Z] Ada: Ship it.");
+    expect(telegram.warnings.join(" ")).toContain("non-message or textless");
+
+    const slack = renderChatExport("slack", slackExport, { maximumOutputBytes: 1_000_000 });
+    expect(slack.content).toContain("rollback & retry");
+    expect(slack.content).toContain("[2026-02-25T06:14:20.000Z] grace: agreed");
+    expect(slack.participants).toEqual(["U1", "grace"]);
+
+    const discord = renderChatExport("discord", discordExport, {
+      maximumOutputBytes: 1_000_000,
+    });
+    expect(discord.content).toContain("## incidents");
+    expect(discord.content).toContain(
+      "[2026-03-05T10:00:00.000Z] Ada: The failure mode was a cache key.",
+    );
+    expect(discord.warnings.join(" ")).toContain("1 attachment(s)");
+  });
+
+  it("keeps a timezone-naive timestamp exactly as exported", () => {
+    const transcript = renderChatExport(
+      "telegram",
+      {
+        name: "naive",
+        messages: [{ type: "message", from: "Ada", date: "2026-03-05T10:00:00", text: "hi" }],
+      },
+      { maximumOutputBytes: 1_000_000 },
+    );
+    expect(transcript.content).toContain("[2026-03-05T10:00:00] Ada: hi");
+  });
+
+  it("stops at the output limit and says what was left out", () => {
+    const transcript = renderChatExport("claude", claudeExport, { maximumOutputBytes: 120 });
+    expect(transcript.messageCount).toBeLessThan(3);
+    expect(transcript.warnings.join(" ")).toContain("left out to stay within the output limit");
+  });
+
+  it("is deterministic for one input", () => {
+    const first = renderChatExport("chatgpt", chatGptExport, { maximumOutputBytes: 1_000_000 });
+    const second = renderChatExport("chatgpt", chatGptExport, { maximumOutputBytes: 1_000_000 });
+    expect(second).toEqual(first);
+  });
+});
+
+describe("json parser integration", () => {
+  const parser = createBuiltinParserRegistry().select("application/json")!;
+
+  it("turns a chat export into a transcript material with participants", async () => {
+    const parsed = await parser.parse(raw(chatGptExport), context);
+    expect(parsed.material?.kind).toBe("transcript");
+    expect(parsed.material?.participants).toEqual(["user", "assistant", "user (profile)"]);
+    expect(parsed.material?.extraction).toMatchObject({
+      method: "document_text",
+      producer: "distilly-json:chatgpt",
+    });
+    expect(parsed.warnings.join(" ")).toContain("Rendered 3 message(s) from 1 conversation(s).");
+  });
+
+  it("keeps the stable pretty-printed document for any other JSON", async () => {
+    const parsed = await parser.parse(raw({ b: 1, a: [{ d: 2, c: 3 }] }), context);
+    expect(parsed.material?.kind).toBe("document");
+    expect(parsed.material?.content).toBe(
+      '{\n  "a": [\n    {\n      "c": 3,\n      "d": 2\n    }\n  ],\n  "b": 1\n}',
+    );
+  });
+
+  it("stores an export with no message text as unparsed with a warning", async () => {
+    const parsed = await parser.parse(
+      raw([{ title: "empty", mapping: {}, current_node: "x" }]),
+      context,
+    );
+    expect(parsed.material).toBeUndefined();
+    expect(parsed.warnings.join(" ")).toContain("contained no message text");
+  });
+});

--- a/packages/adapters/src/chat-export-parser.ts
+++ b/packages/adapters/src/chat-export-parser.ts
@@ -1,0 +1,552 @@
+/**
+ * Detects and renders common chat-export JSON files as deterministic transcripts.
+ *
+ * A user who wants a person distilled usually already owns the conversation: ChatGPT, Claude,
+ * Telegram, Slack, and Discord all export JSON. Those files are ordinary `application/json`,
+ * so one detector has to tell them apart structurally instead of by file name, and the result
+ * has to preserve every utterance exactly as written, because claims later quote this content.
+ *
+ * Rendering is deterministic for one input: conversations keep their file order, messages keep
+ * their in-conversation order, and timestamps are normalized to UTC ISO text only when the
+ * value carries an unambiguous instant.
+ */
+
+/** Chat-export shapes this module recognizes. */
+export type ChatExportKind = "chatgpt" | "claude" | "discord" | "slack" | "telegram";
+
+/** One rendered transcript plus what the renderer had to leave out. */
+export interface ChatExportTranscript {
+  readonly kind: ChatExportKind;
+  readonly content: string;
+  readonly participants: readonly string[];
+  readonly conversationCount: number;
+  readonly messageCount: number;
+  readonly warnings: readonly string[];
+}
+
+/** One normalized utterance. */
+interface TranscriptMessage {
+  readonly speaker: string;
+  readonly at?: string;
+  readonly text: string;
+}
+
+/** One normalized conversation. */
+interface TranscriptConversation {
+  readonly title: string;
+  readonly at?: string;
+  readonly messages: readonly TranscriptMessage[];
+}
+
+/** Bounds one render so a giant export cannot exceed the parser's output budget. */
+export interface ChatExportLimits {
+  readonly maximumOutputBytes: number;
+}
+
+const encoder = new TextEncoder();
+
+/**
+ * Reports whether a JSON value is a non-null object with string keys.
+ *
+ * @param value - Candidate JSON value.
+ * @returns True when the value can be read as a record.
+ */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Reads an array element at one index without trusting the array's length.
+ *
+ * @param value - Candidate JSON value.
+ * @returns The array, or undefined when the value is not an array.
+ */
+const asArray = (value: unknown): readonly unknown[] | undefined =>
+  Array.isArray(value) ? value : undefined;
+
+/**
+ * Reads a non-empty string field.
+ *
+ * @param value - Candidate JSON value.
+ * @returns The trimmed string, or undefined when it is absent or blank.
+ */
+const asText = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim().length > 0 ? value : undefined;
+
+/**
+ * Normalizes one exported timestamp to UTC ISO text when the instant is unambiguous.
+ *
+ * Epoch seconds (ChatGPT, Slack) and offset-bearing ISO text (Telegram, Discord, Claude)
+ * describe one instant; a timezone-naive timestamp is kept verbatim rather than guessed at.
+ *
+ * @param value - Timestamp field from the export.
+ * @returns ISO 8601 UTC text, the original offset-bearing text, or undefined.
+ */
+const normalizeInstant = (value: unknown): string | undefined => {
+  const numeric = typeof value === "number" ? value : undefined;
+  const text = numeric === undefined ? asText(value) : undefined;
+  if (numeric !== undefined || (text !== undefined && /^\d+(?:\.\d+)?$/u.test(text))) {
+    const seconds = numeric ?? Number(text);
+    if (!Number.isFinite(seconds) || seconds <= 0) return undefined;
+    // A value past 1e11 cannot be a seconds epoch inside this century, so it is milliseconds.
+    const milliseconds = seconds >= 1e11 ? seconds : seconds * 1000;
+    return new Date(Math.round(milliseconds)).toISOString();
+  }
+  if (text === undefined) return undefined;
+  const parsed = Date.parse(text);
+  if (Number.isNaN(parsed)) return undefined;
+  // A timestamp without a zone is a local wall clock: keep it exactly as exported.
+  return /(?:Z|[+-]\d{2}:?\d{2})$/u.test(text) ? new Date(parsed).toISOString() : text;
+};
+
+/**
+ * Joins exported message parts into one utterance.
+ *
+ * ChatGPT stores text parts as a mixed array of strings and typed objects; Telegram stores
+ * either a string or a list of entities. Anything unrecognized is skipped rather than
+ * stringified, so no synthetic text can end up quoted as evidence.
+ *
+ * @param value - Message text field from the export.
+ * @returns The joined text, or undefined when the field carries no text.
+ */
+const textFromParts = (value: unknown): string | undefined => {
+  if (typeof value === "string") return value.length === 0 ? undefined : value;
+  const parts = asArray(value);
+  if (parts === undefined) return undefined;
+  const pieces: string[] = [];
+  for (const part of parts) {
+    if (typeof part === "string") {
+      pieces.push(part);
+      continue;
+    }
+    if (!isRecord(part)) continue;
+    const text = asText(part["text"]);
+    if (text !== undefined) pieces.push(text);
+  }
+  const joined = pieces.join("");
+  return joined.length === 0 ? undefined : joined;
+};
+
+/** Reads the ordered message path of one ChatGPT conversation from its mapping tree. */
+/**
+ * Reads the text and speaker label of one ChatGPT content object.
+ *
+ * `model_editable_context` is the assistant's own bookkeeping and is never evidence. The
+ * `user_editable_context` object carries the person's standing profile, instructions, and
+ * memory, which is exactly the kind of statement a persona distillation needs, so it is kept
+ * with a speaker label that shows where it came from instead of being dropped.
+ *
+ * @param content - Message content object from the export.
+ * @returns Text plus an optional speaker suffix, or nothing when the object carries no text.
+ */
+const chatGptContent = (
+  content: Record<string, unknown>,
+): { readonly text?: string; readonly speakerSuffix?: string } => {
+  const contentType = asText(content["content_type"]);
+  if (contentType === "model_editable_context") return {};
+  if (contentType === "user_editable_context") {
+    const fields = ["user_profile", "user_instructions", "user_memory"]
+      .map((key) => asText(content[key]))
+      .filter((value): value is string => value !== undefined);
+    return fields.length === 0 ? {} : { text: fields.join("\n\n"), speakerSuffix: " (profile)" };
+  }
+  const text = textFromParts(content["parts"]);
+  return text === undefined ? {} : { text };
+};
+
+const chatGptPath = (
+  mapping: Record<string, unknown>,
+  currentNode: string | undefined,
+): readonly string[] => {
+  const end = currentNode !== undefined && isRecord(mapping[currentNode]) ? currentNode : undefined;
+  if (end === undefined) return [];
+  const order: string[] = [];
+  const seen = new Set<string>();
+  let cursor: string | undefined = end;
+  while (cursor !== undefined && !seen.has(cursor)) {
+    seen.add(cursor);
+    const node: unknown = mapping[cursor];
+    if (!isRecord(node)) break;
+    order.push(cursor);
+    const parent = node["parent"];
+    cursor = typeof parent === "string" ? parent : undefined;
+  }
+  return order.reverse();
+};
+
+/**
+ * Renders the conversations of one ChatGPT export along each conversation's current path.
+ *
+ * @param value - Parsed export value.
+ * @returns Rendered conversations plus what was skipped.
+ */
+const readChatGpt = (
+  value: unknown,
+): { readonly conversations: readonly TranscriptConversation[]; readonly warnings: string[] } => {
+  const warnings: string[] = [];
+  const conversations: TranscriptConversation[] = [];
+  if (!Array.isArray(value)) return { conversations, warnings };
+  let skippedBranches = 0;
+  let skippedMessages = 0;
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const mapping = entry["mapping"];
+    if (!isRecord(mapping)) continue;
+    const path = chatGptPath(mapping, asText(entry["current_node"]));
+    if (path.length === 0) {
+      skippedBranches += Object.keys(mapping).length;
+      continue;
+    }
+    skippedBranches += Math.max(0, Object.keys(mapping).length - path.length);
+    const messages: TranscriptMessage[] = [];
+    for (const key of path) {
+      const node: unknown = mapping[key];
+      if (!isRecord(node)) continue;
+      const message: unknown = node["message"];
+      if (!isRecord(message)) continue;
+      const author: unknown = message["author"];
+      const role = isRecord(author) ? (asText(author["role"]) ?? "unknown") : "unknown";
+      const content: unknown = message["content"];
+      const read = isRecord(content) ? chatGptContent(content) : {};
+      if (read.text === undefined) {
+        skippedMessages += 1;
+        continue;
+      }
+      const at = normalizeInstant(message["create_time"]);
+      messages.push({
+        speaker: `${role}${read.speakerSuffix ?? ""}`,
+        ...(at === undefined ? {} : { at }),
+        text: read.text,
+      });
+    }
+    const title = asText(entry["title"]) ?? "Untitled conversation";
+    const at = normalizeInstant(entry["create_time"]);
+    if (messages.length > 0)
+      conversations.push({ title, ...(at === undefined ? {} : { at }), messages });
+  }
+  if (skippedBranches > 0) {
+    warnings.push(
+      `${String(skippedBranches)} message node(s) outside each conversation's current path were not included as evidence.`,
+    );
+  }
+  if (skippedMessages > 0) {
+    warnings.push(`${String(skippedMessages)} message(s) carried no text and were skipped.`);
+  }
+  return { conversations, warnings };
+};
+
+/**
+ * Reads one array-of-conversations export that stores `chat_messages` per conversation.
+ *
+ * @param value - Parsed export value.
+ * @returns Rendered conversations plus what was skipped.
+ */
+const readClaude = (
+  value: unknown,
+): { readonly conversations: readonly TranscriptConversation[]; readonly warnings: string[] } => {
+  const warnings: string[] = [];
+  const conversations: TranscriptConversation[] = [];
+  if (!Array.isArray(value)) return { conversations, warnings };
+  let skipped = 0;
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const rawMessages = asArray(entry["chat_messages"]);
+    if (rawMessages === undefined) continue;
+    const messages: TranscriptMessage[] = [];
+    for (const raw of rawMessages) {
+      if (!isRecord(raw)) continue;
+      const text = asText(raw["text"]);
+      if (text === undefined) {
+        skipped += 1;
+        continue;
+      }
+      const speaker = asText(raw["sender"]) ?? "unknown";
+      const at = normalizeInstant(raw["created_at"]);
+      messages.push({ speaker, ...(at === undefined ? {} : { at }), text });
+    }
+    if (messages.length === 0) continue;
+    const title = asText(entry["name"]) ?? "Untitled conversation";
+    const at = normalizeInstant(entry["created_at"]);
+    conversations.push({ title, ...(at === undefined ? {} : { at }), messages });
+  }
+  if (skipped > 0) warnings.push(`${String(skipped)} message(s) carried no text and were skipped.`);
+  return { conversations, warnings };
+};
+
+/**
+ * Reads a Slack channel export, where each message carries `ts` and a user or bot name.
+ *
+ * @param value - Parsed export value.
+ * @returns Rendered conversations plus what was skipped.
+ */
+const readSlack = (
+  value: unknown,
+): { readonly conversations: readonly TranscriptConversation[]; readonly warnings: string[] } => {
+  const warnings: string[] = [];
+  const rawMessages = isRecord(value) ? asArray(value["messages"]) : undefined;
+  if (rawMessages === undefined) return { conversations: [], warnings };
+  const messages: TranscriptMessage[] = [];
+  let skipped = 0;
+  for (const raw of rawMessages) {
+    if (!isRecord(raw)) continue;
+    const text = asText(raw["text"]);
+    if (text === undefined) {
+      skipped += 1;
+      continue;
+    }
+    const speaker =
+      asText(raw["username"]) ?? asText(raw["user"]) ?? asText(raw["bot_id"]) ?? "unknown";
+    const at = normalizeInstant(raw["ts"]);
+    messages.push({
+      speaker,
+      ...(at === undefined ? {} : { at }),
+      text: decodeSlackEntities(text),
+    });
+  }
+  if (skipped > 0) warnings.push(`${String(skipped)} message(s) carried no text and were skipped.`);
+  const channel = isRecord(value) ? asText(value["channel"]) : undefined;
+  const channelName = isRecord(value) ? asText(value["name"]) : undefined;
+  if (messages.length === 0) return { conversations: [], warnings };
+  return {
+    conversations: [{ title: channelName ?? channel ?? "Slack conversation", messages }],
+    warnings,
+  };
+};
+
+/**
+ * Reverses Slack's three XML entities so quoted text matches what the user typed.
+ *
+ * @param text - Raw Slack message text.
+ * @returns Text with `&amp;`, `&lt;`, and `&gt;` decoded.
+ */
+const decodeSlackEntities = (text: string): string =>
+  text.replace(/&(?:amp|lt|gt);/gu, (entity) => {
+    if (entity === "&amp;") return "&";
+    return entity === "&lt;" ? "<" : ">";
+  });
+
+/**
+ * Reads a Telegram `result.json` export.
+ *
+ * @param value - Parsed export value.
+ * @returns Rendered conversations plus what was skipped.
+ */
+const readTelegram = (
+  value: unknown,
+): { readonly conversations: readonly TranscriptConversation[]; readonly warnings: string[] } => {
+  const warnings: string[] = [];
+  const rawMessages = isRecord(value) ? asArray(value["messages"]) : undefined;
+  if (rawMessages === undefined) return { conversations: [], warnings };
+  const messages: TranscriptMessage[] = [];
+  let skipped = 0;
+  for (const raw of rawMessages) {
+    if (!isRecord(raw)) continue;
+    if (asText(raw["type"]) !== undefined && asText(raw["type"]) !== "message") {
+      skipped += 1;
+      continue;
+    }
+    const text = textFromParts(raw["text"]);
+    if (text === undefined) {
+      skipped += 1;
+      continue;
+    }
+    const speaker = asText(raw["from"]) ?? asText(raw["from_id"]) ?? "unknown";
+    const at = normalizeInstant(raw["date"]);
+    messages.push({ speaker, ...(at === undefined ? {} : { at }), text });
+  }
+  if (skipped > 0) {
+    warnings.push(`${String(skipped)} non-message or textless entr(ies) were skipped.`);
+  }
+  if (messages.length === 0) return { conversations: [], warnings };
+  const title = isRecord(value) ? (asText(value["name"]) ?? "Telegram chat") : "Telegram chat";
+  return { conversations: [{ title, messages }], warnings };
+};
+
+/**
+ * Reads a Discord export, including the DiscordChatExporter wrapper.
+ *
+ * @param value - Parsed export value.
+ * @returns Rendered conversations plus what was skipped.
+ */
+const readDiscord = (
+  value: unknown,
+): { readonly conversations: readonly TranscriptConversation[]; readonly warnings: string[] } => {
+  const warnings: string[] = [];
+  if (!isRecord(value)) return { conversations: [], warnings };
+  const rawMessages = asArray(value["messages"]);
+  if (rawMessages === undefined) return { conversations: [], warnings };
+  const messages: TranscriptMessage[] = [];
+  let skipped = 0;
+  let attachments = 0;
+  for (const raw of rawMessages) {
+    if (!isRecord(raw)) continue;
+    const author: unknown = raw["author"];
+    const speaker = isRecord(author)
+      ? (asText(author["nickname"]) ?? asText(author["name"]) ?? asText(author["id"]) ?? "unknown")
+      : "unknown";
+    const text = asText(raw["content"]);
+    if (text === undefined) {
+      skipped += 1;
+      continue;
+    }
+    attachments += asArray(raw["attachments"])?.length ?? 0;
+    const at = normalizeInstant(raw["timestamp"]);
+    messages.push({ speaker, ...(at === undefined ? {} : { at }), text });
+  }
+  if (skipped > 0) warnings.push(`${String(skipped)} message(s) carried no text and were skipped.`);
+  if (attachments > 0) {
+    warnings.push(`${String(attachments)} attachment(s) were not included as evidence.`);
+  }
+  if (messages.length === 0) return { conversations: [], warnings };
+  const channel: unknown = value["channel"];
+  const title = isRecord(channel)
+    ? (asText(channel["name"]) ?? asText(channel["id"]) ?? "Discord channel")
+    : "Discord channel";
+  return { conversations: [{ title, messages }], warnings };
+};
+
+/**
+ * Identifies which chat export a JSON value is, using structure rather than file name.
+ *
+ * @param value - Parsed JSON value.
+ * @returns The recognized export kind, or undefined for any other JSON document.
+ */
+export const detectChatExport = (value: unknown): ChatExportKind | undefined => {
+  const entries = Array.isArray(value) ? value : [];
+  if (
+    entries.some(
+      (entry) =>
+        isRecord(entry) &&
+        isRecord(entry["mapping"]) &&
+        (asText(entry["current_node"]) !== undefined || asText(entry["title"]) !== undefined),
+    )
+  ) {
+    return "chatgpt";
+  }
+  if (entries.some((entry) => isRecord(entry) && asArray(entry["chat_messages"]) !== undefined)) {
+    return "claude";
+  }
+  if (!isRecord(value)) return undefined;
+  const messages = asArray(value["messages"]);
+  if (messages === undefined) return undefined;
+  if (
+    messages.some(
+      (message) =>
+        isRecord(message) &&
+        isRecord(message["author"]) &&
+        (asText(message["content"]) !== undefined || asText(message["timestamp"]) !== undefined),
+    )
+  ) {
+    return "discord";
+  }
+  if (
+    messages.some(
+      (message) =>
+        isRecord(message) &&
+        asText(message["ts"]) !== undefined &&
+        (asText(message["user"]) !== undefined ||
+          asText(message["username"]) !== undefined ||
+          asText(message["bot_id"]) !== undefined),
+    )
+  ) {
+    return "slack";
+  }
+  if (
+    messages.some(
+      (message) =>
+        isRecord(message) &&
+        asText(message["date"]) !== undefined &&
+        (asText(message["from"]) !== undefined || asText(message["from_id"]) !== undefined),
+    )
+  ) {
+    return "telegram";
+  }
+  return undefined;
+};
+
+/**
+ * Renders one detected chat export as a transcript that keeps every utterance verbatim.
+ *
+ * @param kind - Detected export kind.
+ * @param value - Parsed JSON value.
+ * @param limits - Output byte budget, so a giant export stops with a visible warning.
+ * @returns The transcript, its participants, and every omission the renderer made.
+ */
+export const renderChatExport = (
+  kind: ChatExportKind,
+  value: unknown,
+  limits: ChatExportLimits,
+): ChatExportTranscript => {
+  const read =
+    kind === "chatgpt"
+      ? readChatGpt(value)
+      : kind === "claude"
+        ? readClaude(value)
+        : kind === "slack"
+          ? readSlack(value)
+          : kind === "telegram"
+            ? readTelegram(value)
+            : readDiscord(value);
+  const warnings = [...read.warnings];
+  const header = HEADERS[kind];
+  const lines: string[] = [header];
+  const participants: string[] = [];
+  let bytes = encoder.encode(`${header}\n`).byteLength;
+  let messageCount = 0;
+  let conversationCount = 0;
+  let truncated = 0;
+  for (const conversation of read.conversations) {
+    if (bytes >= limits.maximumOutputBytes) {
+      truncated += 1;
+      continue;
+    }
+    const heading = `\n## ${conversation.title}${conversation.at === undefined ? "" : ` (${conversation.at})`}`;
+    const headingBytes = encoder.encode(`${heading}\n`).byteLength;
+    if (bytes + headingBytes > limits.maximumOutputBytes) {
+      truncated += 1;
+      continue;
+    }
+    lines.push(heading);
+    bytes += headingBytes;
+    conversationCount += 1;
+    for (const message of conversation.messages) {
+      const prefix =
+        message.at === undefined
+          ? `[unknown time] ${message.speaker}: `
+          : `[${message.at}] ${message.speaker}: `;
+      const rendered = `${prefix}${message.text}`;
+      const renderedBytes = encoder.encode(`${rendered}\n`).byteLength;
+      if (bytes + renderedBytes > limits.maximumOutputBytes) {
+        truncated += 1;
+        continue;
+      }
+      lines.push(rendered);
+      bytes += renderedBytes;
+      messageCount += 1;
+      if (!participants.includes(message.speaker) && participants.length < 32) {
+        participants.push(message.speaker);
+      }
+    }
+  }
+  if (truncated > 0) {
+    warnings.push(
+      `${String(truncated)} conversation(s) or message(s) were left out to stay within the output limit.`,
+    );
+  }
+  return {
+    kind,
+    content: `${lines.join("\n")}\n`,
+    participants,
+    conversationCount,
+    messageCount,
+    warnings,
+  };
+};
+
+/** First line written for each recognized export. */
+const HEADERS: Readonly<Record<ChatExportKind, string>> = Object.freeze({
+  chatgpt: "# ChatGPT conversation export",
+  claude: "# Claude conversation export",
+  slack: "# Slack conversation export",
+  telegram: "# Telegram conversation export",
+  discord: "# Discord conversation export",
+});

--- a/packages/cli/src/harvest-state.test.ts
+++ b/packages/cli/src/harvest-state.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -10,6 +10,7 @@ import {
   loadHarvestState,
   planHarvest,
   recordHarvest,
+  recordedPath,
   saveHarvestState,
   type HarvestState,
 } from "./harvest-state.js";
@@ -44,7 +45,7 @@ describe("harvest record", () => {
     await writeFile(note, "first version\n");
     const digest = await hashFile(note);
     const first = recordHarvest(EMPTY_HARVEST_STATE, "subject_a", [
-      { ...file(note, "note.md"), sha256: digest },
+      { ...file(note, "note.md"), sha256: digest, recordedPath: note },
     ]);
     await saveHarvestState(path, first);
     const loaded = await loadHarvestState(path);
@@ -52,7 +53,7 @@ describe("harvest record", () => {
 
     await writeFile(note, "second version\n");
     const second = recordHarvest(loaded, "subject_a", [
-      { ...file(note, "note.md", 15), sha256: await hashFile(note) },
+      { ...file(note, "note.md", 15), sha256: await hashFile(note), recordedPath: note },
     ]);
     expect(second.entries["subject_a"]).toHaveLength(1);
     expect(second.entries["subject_a"]?.[0]?.sha256).not.toBe(digest);
@@ -106,9 +107,13 @@ describe("harvest dedupe plan", () => {
 
   it("skips only files whose recorded bytes match and keeps edited ones", () => {
     const files = [
-      { ...file("/data/same.md", "same.md"), sha256: digest },
-      { ...file("/data/edited.md", "edited.md"), sha256: "c".repeat(64) },
-      { ...file("/data/new.md", "new.md"), sha256: "d".repeat(64) },
+      { ...file("/data/same.md", "same.md"), sha256: digest, recordedPath: "/data/same.md" },
+      {
+        ...file("/data/edited.md", "edited.md"),
+        sha256: "c".repeat(64),
+        recordedPath: "/data/edited.md",
+      },
+      { ...file("/data/new.md", "new.md"), sha256: "d".repeat(64), recordedPath: "/data/new.md" },
     ];
     const plan = planHarvest(files, [
       { path: "/data/same.md", sha256: digest, sizeBytes: 10 },
@@ -118,31 +123,64 @@ describe("harvest dedupe plan", () => {
     expect(plan.ingest.map((entry) => entry.pathLabel)).toEqual(["edited.md", "new.md"]);
   });
 
-  it("matches a recorded relative path against the absolute selection", () => {
+  it("matches a recorded entry only when the real path is identical", () => {
     const plan = planHarvest(
-      [{ ...file("/data/sub/note.md", "note.md"), sha256: digest }],
-      [{ path: "/data/sub/./note.md", sha256: digest, sizeBytes: 10 }],
+      [
+        {
+          ...file("/data/sub/note.md", "note.md"),
+          sha256: digest,
+          recordedPath: "/private/data/sub/note.md",
+        },
+      ],
+      [{ path: "/private/data/sub/note.md", sha256: digest, sizeBytes: 10 }],
     );
     expect(plan.alreadyIngested).toHaveLength(1);
     expect(plan.ingest).toHaveLength(0);
+    const other = planHarvest(
+      [
+        {
+          ...file("/data/sub/note.md", "note.md"),
+          sha256: digest,
+          recordedPath: "/data/sub/note.md",
+        },
+      ],
+      [{ path: "/private/data/sub/note.md", sha256: digest, sizeBytes: 10 }],
+    );
+    expect(other.ingest).toHaveLength(1);
   });
 
   it("records a state per subject, so another subject still ingests the same bytes", () => {
-    const first: HarvestState = recordHarvest(EMPTY_HARVEST_STATE, "subject_a", [
-      { ...file("/data/note.md", "note.md"), sha256: digest },
-    ]);
+    const entry = {
+      ...file("/data/note.md", "note.md"),
+      sha256: digest,
+      recordedPath: "/data/note.md",
+    };
+    const first: HarvestState = recordHarvest(EMPTY_HARVEST_STATE, "subject_a", [entry]);
     expect(
       planHarvest(
-        [{ ...file("/data/note.md", "note.md"), sha256: digest }],
+        [{ ...file("/data/note.md", "note.md"), sha256: digest, recordedPath: "/data/note.md" }],
         first.entries["subject_b"] ?? [],
       ).ingest,
     ).toHaveLength(1);
     expect(
       planHarvest(
-        [{ ...file("/data/note.md", "note.md"), sha256: digest }],
+        [{ ...file("/data/note.md", "note.md"), sha256: digest, recordedPath: "/data/note.md" }],
         first.entries["subject_a"] ?? [],
       ).alreadyIngested,
     ).toHaveLength(1);
+  });
+});
+
+describe("recorded path", () => {
+  it("resolves a symlinked path to the real one and falls back for a missing file", async () => {
+    const root = await temporaryRoot();
+    const target = join(root, "real");
+    await mkdir(target);
+    await writeFile(join(target, "note.md"), "note\n");
+    const link = join(root, "link");
+    await symlink(target, link, "dir");
+    expect(await recordedPath(join(link, "note.md"))).toBe(join(await realpath(target), "note.md"));
+    expect(await recordedPath(join(root, "missing.md"))).toBe(join(root, "missing.md"));
   });
 });
 

--- a/packages/cli/src/harvest-state.test.ts
+++ b/packages/cli/src/harvest-state.test.ts
@@ -1,0 +1,159 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  EMPTY_HARVEST_STATE,
+  hashFile,
+  loadHarvestState,
+  planHarvest,
+  recordHarvest,
+  saveHarvestState,
+  type HarvestState,
+} from "./harvest-state.js";
+
+import type { HarvestFile } from "./harvest.js";
+
+const roots: string[] = [];
+
+const temporaryRoot = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), "distilly-harvest-state-"));
+  roots.push(root);
+  return root;
+};
+
+const file = (path: string, name: string, sizeBytes = 10): HarvestFile => ({
+  path,
+  pathLabel: name,
+  mediaType: "text/markdown",
+  relativePath: name,
+  sizeBytes,
+});
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+describe("harvest record", () => {
+  it("round-trips entries and replaces the entry for a re-ingested path", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "harvest-state.json");
+    const note = join(root, "note.md");
+    await writeFile(note, "first version\n");
+    const digest = await hashFile(note);
+    const first = recordHarvest(EMPTY_HARVEST_STATE, "subject_a", [
+      { ...file(note, "note.md"), sha256: digest },
+    ]);
+    await saveHarvestState(path, first);
+    const loaded = await loadHarvestState(path);
+    expect(loaded.entries["subject_a"]).toEqual([{ path: note, sha256: digest, sizeBytes: 10 }]);
+
+    await writeFile(note, "second version\n");
+    const second = recordHarvest(loaded, "subject_a", [
+      { ...file(note, "note.md", 15), sha256: await hashFile(note) },
+    ]);
+    expect(second.entries["subject_a"]).toHaveLength(1);
+    expect(second.entries["subject_a"]?.[0]?.sha256).not.toBe(digest);
+  });
+
+  it("treats a missing, malformed, or hand-edited record as nothing recorded", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "harvest-state.json");
+    expect(await loadHarvestState(path)).toEqual(EMPTY_HARVEST_STATE);
+
+    await writeFile(path, "{ not json");
+    expect(await loadHarvestState(path)).toEqual(EMPTY_HARVEST_STATE);
+
+    await writeFile(path, JSON.stringify({ version: 2, entries: {} }));
+    expect(await loadHarvestState(path)).toEqual(EMPTY_HARVEST_STATE);
+
+    await writeFile(
+      path,
+      JSON.stringify({
+        version: 1,
+        entries: { subject_a: [{ path: "/tmp/a", sha256: "short", sizeBytes: 1 }, null] },
+      }),
+    );
+    expect(await loadHarvestState(path)).toEqual(EMPTY_HARVEST_STATE);
+  });
+
+  it("keeps valid entries when a record mixes valid and invalid ones", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "harvest-state.json");
+    const digest = "a".repeat(64);
+    await writeFile(
+      path,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          subject_a: [{ path: "/tmp/a.md", sha256: digest, sizeBytes: 3 }, { path: "/tmp/b" }],
+          subject_b: "not a list",
+        },
+      }),
+    );
+    const loaded = await loadHarvestState(path);
+    expect(loaded.entries["subject_a"]).toEqual([
+      { path: "/tmp/a.md", sha256: digest, sizeBytes: 3 },
+    ]);
+    expect(loaded.entries["subject_b"]).toBeUndefined();
+  });
+});
+
+describe("harvest dedupe plan", () => {
+  const digest = "b".repeat(64);
+
+  it("skips only files whose recorded bytes match and keeps edited ones", () => {
+    const files = [
+      { ...file("/data/same.md", "same.md"), sha256: digest },
+      { ...file("/data/edited.md", "edited.md"), sha256: "c".repeat(64) },
+      { ...file("/data/new.md", "new.md"), sha256: "d".repeat(64) },
+    ];
+    const plan = planHarvest(files, [
+      { path: "/data/same.md", sha256: digest, sizeBytes: 10 },
+      { path: "/data/edited.md", sha256: "e".repeat(64), sizeBytes: 10 },
+    ]);
+    expect(plan.alreadyIngested.map((entry) => entry.pathLabel)).toEqual(["same.md"]);
+    expect(plan.ingest.map((entry) => entry.pathLabel)).toEqual(["edited.md", "new.md"]);
+  });
+
+  it("matches a recorded relative path against the absolute selection", () => {
+    const plan = planHarvest(
+      [{ ...file("/data/sub/note.md", "note.md"), sha256: digest }],
+      [{ path: "/data/sub/./note.md", sha256: digest, sizeBytes: 10 }],
+    );
+    expect(plan.alreadyIngested).toHaveLength(1);
+    expect(plan.ingest).toHaveLength(0);
+  });
+
+  it("records a state per subject, so another subject still ingests the same bytes", () => {
+    const first: HarvestState = recordHarvest(EMPTY_HARVEST_STATE, "subject_a", [
+      { ...file("/data/note.md", "note.md"), sha256: digest },
+    ]);
+    expect(
+      planHarvest(
+        [{ ...file("/data/note.md", "note.md"), sha256: digest }],
+        first.entries["subject_b"] ?? [],
+      ).ingest,
+    ).toHaveLength(1);
+    expect(
+      planHarvest(
+        [{ ...file("/data/note.md", "note.md"), sha256: digest }],
+        first.entries["subject_a"] ?? [],
+      ).alreadyIngested,
+    ).toHaveLength(1);
+  });
+});
+
+describe("file hashing", () => {
+  it("hashes the exact bytes", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "note.md");
+    await writeFile(path, "abc");
+    expect(await hashFile(path)).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+    expect((await readFile(path, "utf8")).length).toBe(3);
+  });
+});

--- a/packages/cli/src/harvest-state.ts
+++ b/packages/cli/src/harvest-state.ts
@@ -1,0 +1,167 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+import type { HarvestFile } from "./harvest.js";
+
+/** One file this store already ingested for one subject, identified by its bytes. */
+export interface HarvestStateEntry {
+  /** Absolute path the bytes were read from. */
+  readonly path: string;
+  /** SHA-256 of the exact bytes that were ingested. */
+  readonly sha256: string;
+  /** Byte length when it was ingested, so an unchanged file needs no second read. */
+  readonly sizeBytes: number;
+}
+
+/** Local record of what harvest already ingested, so a second run adds no duplicate evidence. */
+export interface HarvestState {
+  readonly version: 1;
+  readonly entries: Readonly<Record<string, readonly HarvestStateEntry[]>>;
+}
+
+/** The empty state used when no record exists yet or the record is unreadable. */
+export const EMPTY_HARVEST_STATE: HarvestState = Object.freeze({
+  version: 1,
+  entries: Object.freeze({}),
+});
+
+/**
+ * Reads the harvest record, treating any unreadable or malformed file as "nothing recorded".
+ *
+ * The record is a cache of local decisions, never evidence: a corrupt or hand-edited file must
+ * make harvest ingest everything again rather than fail the command or skip real material.
+ *
+ * @param path - State file path.
+ * @returns Parsed state, or the empty state.
+ */
+export const loadHarvestState = async (path: string): Promise<HarvestState> => {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch {
+    return EMPTY_HARVEST_STATE;
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return EMPTY_HARVEST_STATE;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return EMPTY_HARVEST_STATE;
+  }
+  const record = value as { readonly version?: unknown; readonly entries?: unknown };
+  if (record.version !== 1 || typeof record.entries !== "object" || record.entries === null) {
+    return EMPTY_HARVEST_STATE;
+  }
+  const entries: Record<string, HarvestStateEntry[]> = {};
+  for (const [subjectId, list] of Object.entries(record.entries as Record<string, unknown>)) {
+    if (!Array.isArray(list)) continue;
+    const parsed: HarvestStateEntry[] = [];
+    for (const item of list) {
+      if (typeof item !== "object" || item === null) continue;
+      const entry = item as { path?: unknown; sha256?: unknown; sizeBytes?: unknown };
+      if (
+        typeof entry.path !== "string" ||
+        typeof entry.sha256 !== "string" ||
+        !/^[0-9a-f]{64}$/u.test(entry.sha256) ||
+        typeof entry.sizeBytes !== "number" ||
+        !Number.isSafeInteger(entry.sizeBytes)
+      ) {
+        continue;
+      }
+      parsed.push({ path: entry.path, sha256: entry.sha256, sizeBytes: entry.sizeBytes });
+    }
+    if (parsed.length > 0) entries[subjectId] = parsed;
+  }
+  return { version: 1, entries };
+};
+
+/**
+ * Writes the harvest record atomically, so an interrupted run cannot leave half a record.
+ *
+ * @param path - State file path.
+ * @param state - Record to persist.
+ */
+export const saveHarvestState = async (path: string, state: HarvestState): Promise<void> => {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${String(process.pid)}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(state, undefined, 2)}\n`, { mode: 0o600 });
+  await rename(temporary, path);
+};
+
+/**
+ * Hashes one file's exact bytes.
+ *
+ * @param path - Absolute file path.
+ * @returns Lowercase hexadecimal SHA-256.
+ */
+export const hashFile = async (path: string): Promise<string> =>
+  createHash("sha256")
+    .update(await readFile(path))
+    .digest("hex");
+
+/** One selected file together with the digest of the bytes that will be ingested. */
+export interface HashedHarvestFile extends HarvestFile {
+  readonly sha256: string;
+}
+
+/** What one harvest run should ingest and what it can skip as already recorded. */
+export interface HarvestDedupePlan {
+  readonly ingest: readonly HashedHarvestFile[];
+  readonly alreadyIngested: readonly HashedHarvestFile[];
+}
+
+/**
+ * Splits a selection into files this subject already has and files it still needs.
+ *
+ * A file counts as already ingested only when the recorded bytes hash to the same digest, so
+ * an edited file with the same size is still ingested. A file recorded for a different subject
+ * is always ingested: two people may own byte-identical material on purpose.
+ *
+ * @param files - Selected files with their digests.
+ * @param entries - Recorded entries for the target subject.
+ * @returns The files to ingest and the files already present.
+ */
+export const planHarvest = (
+  files: readonly HashedHarvestFile[],
+  entries: readonly HarvestStateEntry[],
+): HarvestDedupePlan => {
+  const recorded = new Map(entries.map((entry) => [resolve(entry.path), entry.sha256] as const));
+  const ingest: HashedHarvestFile[] = [];
+  const alreadyIngested: HashedHarvestFile[] = [];
+  for (const file of files) {
+    const previous = recorded.get(resolve(file.path));
+    if (previous !== undefined && previous === file.sha256) alreadyIngested.push(file);
+    else ingest.push(file);
+  }
+  return { ingest, alreadyIngested };
+};
+
+/**
+ * Records the files one ingest call stored for a subject, replacing earlier entries per path.
+ *
+ * @param state - Current record.
+ * @param subjectId - Subject the call ingested into.
+ * @param files - Files that call stored, with their digests.
+ * @returns A new record with those entries updated.
+ */
+export const recordHarvest = (
+  state: HarvestState,
+  subjectId: string,
+  files: readonly HashedHarvestFile[],
+): HarvestState => {
+  const existing = (state.entries[subjectId] ?? []).filter(
+    (entry) => !files.some((file) => resolve(file.path) === resolve(entry.path)),
+  );
+  const added = files.map((file) => ({
+    path: resolve(file.path),
+    sha256: file.sha256,
+    sizeBytes: file.sizeBytes,
+  }));
+  return {
+    version: 1,
+    entries: { ...state.entries, [subjectId]: [...existing, ...added] },
+  };
+};

--- a/packages/cli/src/harvest-state.ts
+++ b/packages/cli/src/harvest-state.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, rename, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
 import type { HarvestFile } from "./harvest.js";
@@ -10,7 +10,7 @@ export interface HarvestStateEntry {
   readonly path: string;
   /** SHA-256 of the exact bytes that were ingested. */
   readonly sha256: string;
-  /** Byte length when it was ingested, so an unchanged file needs no second read. */
+  /** Byte length that was ingested, reported back whenever the entry is listed. */
   readonly sizeBytes: number;
 }
 
@@ -79,15 +79,34 @@ export const loadHarvestState = async (path: string): Promise<HarvestState> => {
 };
 
 /**
- * Writes the harvest record atomically, so an interrupted run cannot leave half a record.
+ * Writes the harvest record atomically, merging what another run recorded in the meantime.
+ *
+ * Two harvests may run at once, so the record on disk is re-read immediately before the
+ * atomic rename and its entries are merged in. Last writer wins per path, but a folder that
+ * another run already recorded is not forgotten just because this run loaded an older copy.
  *
  * @param path - State file path.
  * @param state - Record to persist.
  */
 export const saveHarvestState = async (path: string, state: HarvestState): Promise<void> => {
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const current = await loadHarvestState(path);
+  const merged: Record<string, HarvestStateEntry[]> = {};
+  for (const [subjectId, entries] of Object.entries(current.entries)) {
+    merged[subjectId] = [...entries];
+  }
+  for (const [subjectId, entries] of Object.entries(state.entries)) {
+    const existing = merged[subjectId] ?? [];
+    const replaced = new Set(entries.map((entry) => resolve(entry.path)));
+    merged[subjectId] = [
+      ...existing.filter((entry) => !replaced.has(resolve(entry.path))),
+      ...entries,
+    ];
+  }
   const temporary = `${path}.${String(process.pid)}.tmp`;
-  await writeFile(temporary, `${JSON.stringify(state, undefined, 2)}\n`, { mode: 0o600 });
+  await writeFile(temporary, `${JSON.stringify({ version: 1, entries: merged }, undefined, 2)}\n`, {
+    mode: 0o600,
+  });
   await rename(temporary, path);
 };
 
@@ -102,9 +121,29 @@ export const hashFile = async (path: string): Promise<string> =>
     .update(await readFile(path))
     .digest("hex");
 
+/**
+ * Resolves one selected path to the real path the record is keyed on.
+ *
+ * A directory reached through a symlink or through a different spelling of the same location
+ * (`/tmp/d` and `/private/tmp/d`) is the same folder on disk, so the record must not treat its
+ * files as new evidence.
+ *
+ * @param path - Selected absolute file path.
+ * @returns The real path, or the resolved input when it cannot be read.
+ */
+export const recordedPath = async (path: string): Promise<string> => {
+  try {
+    return await realpath(path);
+  } catch {
+    return resolve(path);
+  }
+};
+
 /** One selected file together with the digest of the bytes that will be ingested. */
 export interface HashedHarvestFile extends HarvestFile {
   readonly sha256: string;
+  /** Real path the record is keyed on, so two spellings of one folder stay one entry. */
+  readonly recordedPath: string;
 }
 
 /** What one harvest run should ingest and what it can skip as already recorded. */
@@ -128,11 +167,11 @@ export const planHarvest = (
   files: readonly HashedHarvestFile[],
   entries: readonly HarvestStateEntry[],
 ): HarvestDedupePlan => {
-  const recorded = new Map(entries.map((entry) => [resolve(entry.path), entry.sha256] as const));
+  const recorded = new Map(entries.map((entry) => [entry.path, entry.sha256] as const));
   const ingest: HashedHarvestFile[] = [];
   const alreadyIngested: HashedHarvestFile[] = [];
   for (const file of files) {
-    const previous = recorded.get(resolve(file.path));
+    const previous = recorded.get(file.recordedPath);
     if (previous !== undefined && previous === file.sha256) alreadyIngested.push(file);
     else ingest.push(file);
   }
@@ -153,10 +192,10 @@ export const recordHarvest = (
   files: readonly HashedHarvestFile[],
 ): HarvestState => {
   const existing = (state.entries[subjectId] ?? []).filter(
-    (entry) => !files.some((file) => resolve(file.path) === resolve(entry.path)),
+    (entry) => !files.some((file) => file.recordedPath === entry.path),
   );
   const added = files.map((file) => ({
-    path: resolve(file.path),
+    path: file.recordedPath,
     sha256: file.sha256,
     sizeBytes: file.sizeBytes,
   }));

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -123,6 +123,49 @@ describe("Developer Preview CLI host boundary", () => {
     expect(stdout).toEqual([]);
   });
 
+  it("requires a host for personas and a subject plus host for remove", async () => {
+    const stdout: string[] = [];
+    const io = {
+      stdout: { write: (value: string) => stdout.push(value) },
+      stderr: { write: (value: string) => value },
+    };
+    await expect(runPreviewCli(["personas"], environment, io)).rejects.toThrow(
+      "This command requires --host.",
+    );
+    await expect(
+      runPreviewCli(["personas", "--host", "codex", "--nope", "1"], environment, io),
+    ).rejects.toThrow("Unknown personas option: --nope.");
+    await expect(runPreviewCli(["remove", "--host", "codex"], environment, io)).rejects.toThrow(
+      "This command requires a subject id or display name, then --host <host>.",
+    );
+    await expect(
+      runPreviewCli(["remove", "   ", "--host", "codex"], environment, io),
+    ).rejects.toThrow("This command requires a subject id or display name, then --host <host>.");
+    await expect(
+      runPreviewCli(["remove", `subject_${"a".repeat(32)}`], environment, io),
+    ).rejects.toThrow("This command requires --host.");
+    await expect(
+      runPreviewCli(
+        ["remove", `subject_${"a".repeat(32)}`, "--host", "codex", "--nope", "1"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("Unknown remove option: --nope.");
+    expect(stdout).toEqual([]);
+  });
+
+  it("documents the person Skill lifecycle commands", async () => {
+    const stdout: string[] = [];
+    await expect(
+      runPreviewCli(["--help"], environment, {
+        stdout: { write: (value: string) => stdout.push(value) },
+        stderr: { write: (value: string) => value },
+      }),
+    ).resolves.toBe(0);
+    expect(stdout.join("")).toContain("distilly personas --host <host>");
+    expect(stdout.join("")).toContain("distilly remove <subject-id|display-name> --host <host>");
+  });
+
   it("documents the standalone panel command and the dsh host", async () => {
     const stdout: string[] = [];
     const stderr: string[] = [];

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -11,6 +11,7 @@ import {
   type HostName,
   type SubjectSummary,
 } from "@distilly/protocol";
+import { listPersonInstalls, type PersonInstallSummary } from "@distilly/bindings";
 import type { Distilly } from "distilly";
 
 import { ambiguousCandidates, reusableSubject } from "./subject-errors.js";
@@ -28,6 +29,7 @@ import {
   loadHarvestState,
   planHarvest,
   recordHarvest,
+  recordedPath,
   saveHarvestState,
   type HashedHarvestFile,
 } from "./harvest-state.js";
@@ -257,9 +259,9 @@ const runHarvest = async (
   io: PreviewCliIo,
 ): Promise<void> => {
   const options = harvestOptions(args);
-  const selection = await selectHarvestFiles(options.directory, {
-    ...(options.maximumFiles === undefined ? {} : { maximumFiles: options.maximumFiles }),
-  });
+  // The limit applies to what is actually ingested, not to what is discovered: applying it
+  // first would keep re-selecting files that are already stored and never reach the rest.
+  const selection = await selectHarvestFiles(options.directory);
   for (const line of describeHarvestSelection(selection)) io.stdout.write(`${line}\n`);
   if (selection.files.length === 0) {
     io.stdout.write("Nothing to ingest.\n");
@@ -294,14 +296,23 @@ const runHarvest = async (
         // The engine treats differently capitalized names as different people, so a new
         // subject is correct here; say so when a near-duplicate exists instead of silently
         // splitting one person's material across two subjects.
-        const page = await application.distilly.list({
-          text: options.displayName ?? "",
-          limit: 32,
-        });
-        const nearDuplicate = page.items.find(
-          (candidate) =>
-            candidate.displayName.toLowerCase() === (options.displayName ?? "").toLowerCase(),
-        );
+        const wanted = (options.displayName ?? "").toLowerCase();
+        let nearDuplicate: SubjectSummary | undefined;
+        let cursor: string | undefined;
+        // Page through the whole filtered listing: the case-variant may sort past any fixed
+        // window, and a missed warning silently splits one person across two subjects.
+        for (let page = 0; page < 20 && nearDuplicate === undefined; page += 1) {
+          const listed = await application.distilly.list({
+            text: options.displayName ?? "",
+            limit: 200,
+            ...(cursor === undefined ? {} : { cursor }),
+          });
+          nearDuplicate = listed.items.find(
+            (candidate) => candidate.displayName.toLowerCase() === wanted,
+          );
+          cursor = listed.nextCursor;
+          if (cursor === undefined) break;
+        }
         if (nearDuplicate !== undefined) {
           io.stdout.write(
             `Note: ${nearDuplicate.displayName} (${nearDuplicate.id}) already exists in ${nearDuplicate.space.displayName} with different capitalization; a new subject is created. Pass --subject ${nearDuplicate.id} to add to that one instead.\n`,
@@ -311,9 +322,22 @@ const runHarvest = async (
     }
     const statePath = join(environment.lifecycle.homeDirectory, ".distilly", "harvest-state.json");
     const state = await loadHarvestState(statePath);
-    let files: HashedHarvestFile[] = await Promise.all(
-      selection.files.map(async (file) => ({ ...file, sha256: await hashFile(file.path) })),
-    );
+    const failures: string[] = [];
+    const hashed: HashedHarvestFile[] = [];
+    for (const file of selection.files) {
+      try {
+        hashed.push({
+          ...file,
+          sha256: await hashFile(file.path),
+          recordedPath: await recordedPath(file.path),
+        });
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : "the file could not be read";
+        failures.push(`${file.pathLabel}: ${reason}`);
+        io.stdout.write(`Could not read ${file.pathLabel}: ${reason}\n`);
+      }
+    }
+    let files = hashed;
     const recorded = subjectId === undefined ? [] : (state.entries[subjectId] ?? []);
     if (!options.force && recorded.length > 0) {
       const plan = planHarvest(files, recorded);
@@ -325,9 +349,25 @@ const runHarvest = async (
         }
       }
       files = [...plan.ingest];
+    } else if (options.force && files.length > 0) {
+      io.stdout.write(
+        `--force re-ingests ${String(files.length)} file(s) even if they are unchanged, so the store gains a new material record for each one.\n`,
+      );
+    }
+    if (options.maximumFiles !== undefined && files.length > options.maximumFiles) {
+      const remaining = files.length - options.maximumFiles;
+      files = files.slice(0, options.maximumFiles);
+      io.stdout.write(
+        `Reached --limit ${String(options.maximumFiles)}; ${String(remaining)} more file(s) still need ingesting. Re-run to continue.\n`,
+      );
     }
     if (files.length === 0) {
       io.stdout.write("Nothing new to ingest.\n");
+      if (failures.length > 0) {
+        throw new Error(
+          `${String(failures.length)} of ${String(selection.files.length)} file(s) could not be ingested:\n${failures.join("\n")}`,
+        );
+      }
       return;
     }
     // A file larger than one material is split by the runtime into parts, so it must travel
@@ -351,7 +391,6 @@ const runHarvest = async (
 
     let ingested = 0;
     let recordedState = state;
-    const failures: string[] = [];
     // Harvest is an explicit user action, so distillation is queued now instead of waiting for
     // the engine's automatic threshold: a single small file previously produced no job and no
     // message, which read as nothing having happened.
@@ -477,6 +516,11 @@ const resolveSubjectArgument = async (
       `No subject exists with id ${argument}. Run distilly subjects --host <host> to list what exists.`,
     );
   }
+  if (argument.startsWith("subject_")) {
+    throw new Error(
+      `"${argument}" is not a valid subject id. Run distilly subjects --host <host> to list what exists.`,
+    );
+  }
   if (resolution.kind === "ambiguous") {
     for (const line of describeAmbiguousSubject(argument, resolution.candidates)) {
       io.stdout.write(`${line}\n`);
@@ -577,8 +621,10 @@ const runSubjects = async (
     const value = args[index + 1];
     if (value === undefined) throw new Error(`Missing value for ${String(flag)}.`);
     if (flag === "--host") host = parseHost(value);
-    else if (flag === "--query") query.text = value;
-    else if (flag === "--cursor") query.cursor = value;
+    else if (flag === "--query") {
+      // An empty filter means "no filter": passing it through would surface a wire error.
+      if (value.trim().length > 0) query.text = value;
+    } else if (flag === "--cursor") query.cursor = value;
     else if (flag === "--limit") {
       const limit = Number.parseInt(value, 10);
       if (!Number.isSafeInteger(limit) || limit <= 0) throw new Error("--limit must be positive.");
@@ -602,13 +648,145 @@ const runSubjects = async (
   }
 };
 
+/**
+ * Renders one person Skill listing, verified installs first and unverified ones named.
+ *
+ * @param summaries - Installs found under the host's skills root.
+ * @param skillsRoot - Root that was scanned, printed so the operator can check it.
+ * @returns Stable report lines.
+ */
+const describePersonInstalls = (
+  summaries: readonly PersonInstallSummary[],
+  skillsRoot: string,
+): readonly string[] => {
+  if (summaries.length === 0) {
+    return [
+      `No person Skill is installed under ${skillsRoot}.`,
+      "Install one with: distilly install <subject-id|display-name> --host <host>",
+    ];
+  }
+  const lines = [`Person Skills under ${skillsRoot}:`];
+  for (const summary of summaries) {
+    lines.push(
+      summary.verified
+        ? `  ${summary.install.path} — ${summary.install.subjectId} @ ${summary.install.versionId} (installed ${summary.install.installedAt})`
+        : `  ${summary.path} — not a verified Distilly install: ${summary.reason}`,
+    );
+  }
+  return lines;
+};
+
+/**
+ * Lists the person Skills installed for one host.
+ *
+ * @param args - Optional --host and --json.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ */
+const runPersonas = async (
+  args: readonly string[],
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<void> => {
+  let host: HostName | undefined;
+  let asJson = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    if (flag === "--json") {
+      asJson = true;
+      continue;
+    }
+    const value = args[index + 1];
+    if (value === undefined) throw new Error(`Missing value for ${String(flag)}.`);
+    if (flag === "--host") host = parseHost(value);
+    else throw new Error(`Unknown personas option: ${String(flag)}.`);
+    index += 1;
+  }
+  if (host === undefined) throw new Error("This command requires --host.");
+  const summaries = await listPersonInstalls(host, environment.lifecycle.homeDirectory);
+  if (asJson) {
+    io.stdout.write(`${JSON.stringify({ host, installs: summaries }, undefined, 2)}\n`);
+    return;
+  }
+  const root = summaries.find((summary) => (summary.verified ? true : summary.host === host));
+  const skillsRoot =
+    root === undefined
+      ? "<no skills root found>"
+      : root.verified
+        ? dirname(root.install.path)
+        : dirname(root.path);
+  io.stdout.write(`${describePersonInstalls(summaries, skillsRoot).join("\n")}\n`);
+};
+
+/**
+ * Removes one person Skill without touching the host integration.
+ *
+ * @param args - Subject id or display name, plus --host.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ */
+const runRemove = async (
+  args: readonly string[],
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<void> => {
+  const [subjectArgument, ...rest] = args;
+  if (
+    subjectArgument === undefined ||
+    subjectArgument.startsWith("--") ||
+    subjectArgument.trim().length === 0
+  ) {
+    throw new Error("This command requires a subject id or display name, then --host <host>.");
+  }
+  let host: HostName | undefined;
+  for (let index = 0; index < rest.length; index += 1) {
+    const flag = rest[index];
+    const value = rest[index + 1];
+    if (value === undefined) throw new Error(`Missing value for ${String(flag)}.`);
+    if (flag === "--host") host = parseHost(value);
+    else throw new Error(`Unknown remove option: ${String(flag)}.`);
+    index += 1;
+  }
+  if (host === undefined) throw new Error("This command requires --host.");
+  const application = await openApplication(host, environment);
+  try {
+    const subject = await resolveSubjectArgument(application.distilly, subjectArgument, io);
+    const summaries = await listPersonInstalls(host, environment.lifecycle.homeDirectory);
+    const install = summaries.find(
+      (summary): summary is Extract<PersonInstallSummary, { verified: true }> =>
+        summary.verified && summary.install.subjectId === subject.id,
+    );
+    if (install === undefined) {
+      const blocked = summaries.find(
+        (summary) => !summary.verified && summary.path.includes(String(subject.id).slice(8, 18)),
+      );
+      if (blocked !== undefined && !blocked.verified) {
+        throw new Error(
+          `The person Skill at ${blocked.path} is not a verified Distilly install: ${blocked.reason}`,
+        );
+      }
+      throw new Error(
+        `${subject.displayName} (${subject.id}) has no installed person Skill for ${host}.`,
+      );
+    }
+    await application.distilly.person(subject.id).uninstall(install.install);
+    io.stdout.write(
+      `Removed the person Skill for ${subject.displayName} at ${install.install.path}.\n`,
+    );
+  } finally {
+    await application.close();
+  }
+};
+
 const help = `Distilly Developer Preview
 
 Usage:
   distilly setup --host codex
   distilly setup --host claude-code|openclaw|hermes|dsh [--allow-unverified-host]
   distilly doctor [--host <host>]
-  distilly install <subject-id> --host <host>
+  distilly install <subject-id|display-name> --host <host>
+  distilly personas --host <host> [--json]
+  distilly remove <subject-id|display-name> --host <host>
   distilly uninstall --host <host>
   distilly panel --host <host>
   distilly subjects --host <host> [--query <text>] [--limit <n>] [--cursor <cursor>] [--json]
@@ -672,17 +850,27 @@ export const runPreviewCli = async (
   }
   if (command === "install") {
     if (args.length !== 3 || args[1] !== "--host") {
-      throw new Error("This command requires <subject-id> --host <host>.");
+      throw new Error("This command requires <subject-id|display-name> --host <host>.");
     }
-    const subjectId = subjectIdSchema.parse(args[0]);
     const host = parseHost(args[2]);
     const application = await openApplication(host, environment);
     try {
-      const installed = await application.distilly.person(subjectId).install(host);
-      io.stdout.write(`Installed ${subjectId} for ${host} at ${installed.path}.\n`);
+      const subject = await resolveSubjectArgument(application.distilly, args[0] ?? "", io);
+      const installed = await application.distilly.person(subject.id).install(host);
+      io.stdout.write(
+        `Installed ${subject.displayName} (${subject.id}) version ${installed.versionId} for ${host} at ${installed.path}.\n`,
+      );
     } finally {
       await application.close();
     }
+    return 0;
+  }
+  if (command === "personas") {
+    await runPersonas(args, environment, io);
+    return 0;
+  }
+  if (command === "remove") {
+    await runRemove(args, environment, io);
     return 0;
   }
   if (command === "mcp") {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -24,6 +24,14 @@ import {
 } from "./lifecycle.js";
 import { describeHarvestSelection, recordBudgetExceeded, selectHarvestFiles } from "./harvest.js";
 import {
+  hashFile,
+  loadHarvestState,
+  planHarvest,
+  recordHarvest,
+  saveHarvestState,
+  type HashedHarvestFile,
+} from "./harvest-state.js";
+import {
   describeAmbiguousSubject,
   describePendingProfile,
   describeProfile,
@@ -187,6 +195,7 @@ const harvestOptions = (
   readonly displayName?: string;
   readonly sensitivity?: "private" | "shareable";
   readonly maximumFiles?: number;
+  readonly force: boolean;
 } => {
   const [directory, ...rest] = args;
   if (directory === undefined || directory.startsWith("--")) {
@@ -198,9 +207,14 @@ const harvestOptions = (
     displayName?: string;
     sensitivity?: "private" | "shareable";
     maximumFiles?: number;
+    force?: boolean;
   } = {};
-  for (let index = 0; index < rest.length; index += 2) {
+  for (let index = 0; index < rest.length; index += 1) {
     const flag = rest[index];
+    if (flag === "--force") {
+      parsed.force = true;
+      continue;
+    }
     const value = rest[index + 1];
     if (value === undefined) throw new Error(`Missing value for ${String(flag)}.`);
     if (flag === "--host") host = parseHost(value);
@@ -218,12 +232,13 @@ const harvestOptions = (
     } else {
       throw new Error(`Unknown harvest option: ${String(flag)}.`);
     }
+    index += 1;
   }
   if (host === undefined) throw new Error("This command requires --host.");
   if ((parsed.subjectId === undefined) === (parsed.displayName === undefined)) {
     throw new Error("Pass exactly one of --subject <subject-id> or --name <display-name>.");
   }
-  return { directory, host, ...parsed };
+  return { directory, host, force: parsed.force === true, ...parsed };
 };
 
 /**
@@ -252,11 +267,74 @@ const runHarvest = async (
   }
   const application = await openApplication(options.host, environment);
   try {
+    let subjectId: string | undefined = options.subjectId;
+    if (subjectId === undefined) {
+      // Resolve the name before creating anything. The engine answers with the one subject it
+      // matched, several candidates, or none, and the CLI acts on that answer instead of
+      // discovering a conflict after a create attempt.
+      const resolution = await application.distilly.resolve({
+        selector: { kind: "query", query: options.displayName ?? "" },
+      });
+      if (resolution.kind === "found") {
+        subjectId = resolution.subject.id;
+        io.stdout.write(
+          `${resolution.subject.displayName} (${resolution.subject.id}) already exists in ${resolution.subject.space.displayName}, so this material is added to it.\n`,
+        );
+      } else if (resolution.kind === "ambiguous") {
+        for (const line of describeAmbiguousSubject(
+          options.displayName ?? "",
+          resolution.candidates,
+        )) {
+          io.stdout.write(`${line}\n`);
+        }
+        throw new Error(
+          "More than one subject matches that name. Repeat harvest with --subject <subject-id>.",
+        );
+      } else {
+        // The engine treats differently capitalized names as different people, so a new
+        // subject is correct here; say so when a near-duplicate exists instead of silently
+        // splitting one person's material across two subjects.
+        const page = await application.distilly.list({
+          text: options.displayName ?? "",
+          limit: 32,
+        });
+        const nearDuplicate = page.items.find(
+          (candidate) =>
+            candidate.displayName.toLowerCase() === (options.displayName ?? "").toLowerCase(),
+        );
+        if (nearDuplicate !== undefined) {
+          io.stdout.write(
+            `Note: ${nearDuplicate.displayName} (${nearDuplicate.id}) already exists in ${nearDuplicate.space.displayName} with different capitalization; a new subject is created. Pass --subject ${nearDuplicate.id} to add to that one instead.\n`,
+          );
+        }
+      }
+    }
+    const statePath = join(environment.lifecycle.homeDirectory, ".distilly", "harvest-state.json");
+    const state = await loadHarvestState(statePath);
+    let files: HashedHarvestFile[] = await Promise.all(
+      selection.files.map(async (file) => ({ ...file, sha256: await hashFile(file.path) })),
+    );
+    const recorded = subjectId === undefined ? [] : (state.entries[subjectId] ?? []);
+    if (!options.force && recorded.length > 0) {
+      const plan = planHarvest(files, recorded);
+      if (plan.alreadyIngested.length > 0) {
+        for (const file of plan.alreadyIngested) {
+          io.stdout.write(
+            `Skipped ${file.pathLabel}: already ingested for this subject; pass --force to ingest it again.\n`,
+          );
+        }
+      }
+      files = [...plan.ingest];
+    }
+    if (files.length === 0) {
+      io.stdout.write("Nothing new to ingest.\n");
+      return;
+    }
     // A file larger than one material is split by the runtime into parts, so it must travel
     // alone: a batch of several oversized files could exceed the wire limit for one result.
-    const batches: (readonly (typeof selection.files)[number][])[] = [];
-    let pending: (typeof selection.files)[number][] = [];
-    for (const file of selection.files) {
+    const batches: (readonly (typeof files)[number][])[] = [];
+    let pending: (typeof files)[number][] = [];
+    for (const file of files) {
       if (file.sizeBytes > WIRE_LIMITS.materialContentBytes) {
         if (pending.length > 0) batches.push(pending);
         batches.push([file]);
@@ -271,8 +349,8 @@ const runHarvest = async (
     }
     if (pending.length > 0) batches.push(pending);
 
-    let subjectId: string | undefined = options.subjectId;
     let ingested = 0;
+    let recordedState = state;
     const failures: string[] = [];
     // Harvest is an explicit user action, so distillation is queued now instead of waiting for
     // the engine's automatic threshold: a single small file previously produced no job and no
@@ -281,14 +359,14 @@ const runHarvest = async (
       target:
         | { readonly kind: "create"; readonly input: { readonly displayName: string } }
         | { readonly kind: "existing"; readonly subjectId: string },
-      files: readonly (typeof selection.files)[number][],
+      batch: readonly (typeof files)[number][],
     ) =>
       await application.distilly.ingestFiles({
         subject:
           target.kind === "create"
             ? { kind: "create", input: target.input }
             : { kind: "existing", subjectId: subjectIdSchema.parse(target.subjectId) },
-        paths: files.map((file) => file.path),
+        paths: batch.map((file) => file.path),
         enqueue: "now",
         ...(options.sensitivity === undefined ? {} : { sensitivity: options.sensitivity }),
       });
@@ -296,9 +374,9 @@ const runHarvest = async (
       subjectId === undefined
         ? ({ kind: "create", input: { displayName: options.displayName ?? "" } } as const)
         : ({ kind: "existing", subjectId } as const);
-    const ingestWithSubjectReuse = async (files: readonly (typeof selection.files)[number][]) => {
+    const ingestWithSubjectReuse = async (batch: readonly (typeof files)[number][]) => {
       try {
-        return await ingest(ingestTarget(), files);
+        return await ingest(ingestTarget(), batch);
       } catch (error) {
         // A second harvest for the same person is normal, not an error: the engine refuses to
         // guess between people and answers with the exact subject it matched. Reusing that
@@ -309,7 +387,7 @@ const runHarvest = async (
           io.stdout.write(
             `${reuse.displayName} (${reuse.id}) already exists, so this material was added to it.\n`,
           );
-          return await ingest({ kind: "existing", subjectId: reuse.id }, files);
+          return await ingest({ kind: "existing", subjectId: reuse.id }, batch);
         }
         const candidates = ambiguousCandidates(error);
         if (candidates === undefined) throw error;
@@ -322,19 +400,29 @@ const runHarvest = async (
         );
       }
     };
+    const store = async (): Promise<void> => {
+      try {
+        await saveHarvestState(statePath, recordedState);
+      } catch {
+        // The record is a local convenience, never evidence: failing to write it must not
+        // fail a harvest that already stored its material.
+      }
+    };
     const recordResult = (
       result: { subject: { id: string; displayName: string } },
       count: number,
+      batch: readonly (typeof files)[number][],
     ) => {
       subjectId = result.subject.id;
       ingested += count;
+      recordedState = recordHarvest(recordedState, result.subject.id, batch);
       io.stdout.write(
-        `Ingested ${String(ingested)}/${String(selection.files.length)} file(s) as ${result.subject.displayName} (${result.subject.id}).\n`,
+        `Ingested ${String(ingested)}/${String(files.length)} new file(s) as ${result.subject.displayName} (${result.subject.id}).\n`,
       );
     };
     for (const batch of batches) {
       try {
-        recordResult(await ingestWithSubjectReuse(batch), batch.length);
+        recordResult(await ingestWithSubjectReuse(batch), batch.length, batch);
       } catch (error) {
         // A batch can exceed the record budget because one file splits into several records.
         // Retry that batch one file per call so one expanding file cannot lose the others.
@@ -344,7 +432,7 @@ const runHarvest = async (
         );
         for (const file of batch) {
           try {
-            recordResult(await ingestWithSubjectReuse([file]), 1);
+            recordResult(await ingestWithSubjectReuse([file]), 1, [file]);
           } catch (fileError) {
             const reason = fileError instanceof Error ? fileError.message : "unknown failure";
             failures.push(`${file.pathLabel}: ${reason}`);
@@ -353,9 +441,10 @@ const runHarvest = async (
         }
       }
     }
+    await store();
     if (failures.length > 0) {
       throw new Error(
-        `${String(failures.length)} of ${String(selection.files.length)} file(s) could not be ingested:\n${failures.join("\n")}`,
+        `${String(failures.length)} of ${String(files.length)} file(s) could not be ingested:\n${failures.join("\n")}`,
       );
     }
   } finally {
@@ -376,12 +465,18 @@ const resolveSubjectArgument = async (
   argument: string,
   io: PreviewCliIo,
 ): Promise<SubjectSummary> => {
+  const asId = looksLikeSubjectId(argument);
   const resolution = await distilly.resolve(
-    looksLikeSubjectId(argument)
+    asId
       ? { selector: { kind: "id", subjectId: subjectIdSchema.parse(argument) } }
       : { selector: { kind: "query", query: argument } },
   );
   if (resolution.kind === "found") return resolution.subject;
+  if (asId) {
+    throw new Error(
+      `No subject exists with id ${argument}. Run distilly subjects --host <host> to list what exists.`,
+    );
+  }
   if (resolution.kind === "ambiguous") {
     for (const line of describeAmbiguousSubject(argument, resolution.candidates)) {
       io.stdout.write(`${line}\n`);
@@ -406,7 +501,11 @@ const runShow = async (
   io: PreviewCliIo,
 ): Promise<void> => {
   const [subjectArgument, ...rest] = args;
-  if (subjectArgument === undefined || subjectArgument.startsWith("--")) {
+  if (
+    subjectArgument === undefined ||
+    subjectArgument.startsWith("--") ||
+    subjectArgument.trim().length === 0
+  ) {
     throw new Error("This command requires a subject id or display name, then --host <host>.");
   }
   let host: HostName | undefined;
@@ -497,7 +596,7 @@ const runSubjects = async (
       io.stdout.write(`${JSON.stringify(page, undefined, 2)}\n`);
       return;
     }
-    io.stdout.write(`${describeSubjectList(page).join("\n")}\n`);
+    io.stdout.write(`${describeSubjectList(page, query.text).join("\n")}\n`);
   } finally {
     await application.close();
   }
@@ -515,7 +614,7 @@ Usage:
   distilly subjects --host <host> [--query <text>] [--limit <n>] [--cursor <cursor>] [--json]
   distilly show <subject-id|display-name> --host <host> [--json]
   distilly harvest <directory> --host <host> --subject <subject-id>|--name <display-name>
-                   [--sensitivity private|shareable] [--limit <n>]
+                   [--sensitivity private|shareable] [--limit <n>] [--force]
   # <host>: codex | claude-code | openclaw | hermes | dsh
 
 The host bindings share the same five-tool MCP contract. Setup remains

--- a/packages/cli/src/show.test.ts
+++ b/packages/cli/src/show.test.ts
@@ -121,6 +121,13 @@ describe("subject argument and listing", () => {
     expect(lines.join("\n")).toContain("distilly harvest <directory> --host <host> --name");
   });
 
+  it("says nothing matched the filter instead of claiming the store is empty", () => {
+    const filtered = describeSubjectList({ items: [] }, "Nobody").join("\n");
+    expect(filtered).toContain('No subject matches "Nobody".');
+    expect(filtered).toContain("distilly subjects --host <host>");
+    expect(filtered).not.toContain("No subjects yet.");
+  });
+
   it("reports a harvested person with no committed profile as a normal state", () => {
     const lines = describePendingProfile(summary("Ada Lovelace", "a", false), {
       subject: summary("Ada Lovelace", "a", false),

--- a/packages/cli/src/show.ts
+++ b/packages/cli/src/show.ts
@@ -141,17 +141,23 @@ export const describeSubject = (subject: SubjectSummary): string => {
 };
 
 /**
- * Renders a subject listing, including what to run when nothing exists yet.
+ * Renders a subject listing, including what to run when nothing matches.
  *
  * @param page - One page of subjects in canonical order.
+ * @param query - Optional text filter the page was requested with.
  * @returns Stable report lines.
  */
-export const describeSubjectList = (page: SubjectPage): readonly string[] => {
+export const describeSubjectList = (page: SubjectPage, query?: string): readonly string[] => {
   if (page.items.length === 0) {
-    return [
-      "No subjects yet.",
-      "Create one from a directory of your own files: distilly harvest <directory> --host <host> --name <display-name>",
-    ];
+    return query === undefined || query.length === 0
+      ? [
+          "No subjects yet.",
+          "Create one from a directory of your own files: distilly harvest <directory> --host <host> --name <display-name>",
+        ]
+      : [
+          `No subject matches "${query}".`,
+          "List every subject with: distilly subjects --host <host>",
+        ];
   }
   const lines = page.items.map((subject) => describeSubject(subject));
   lines.push(

--- a/packages/runtime/src/split-parsed-text.test.ts
+++ b/packages/runtime/src/split-parsed-text.test.ts
@@ -6,11 +6,26 @@ const encoder = new TextEncoder();
 const bytes = (text: string): number => encoder.encode(text).byteLength;
 const maximumBytes = 1_048_576;
 
-const expectReassembles = (text: string, parts: readonly string[]): void => {
-  expect(parts.join("")).toBe(text);
+/**
+ * Mirrors the engine's frozen material-text-v1 canonicalization so parts can be checked.
+ *
+ * @param text - Text to canonicalize.
+ * @returns Canonical text.
+ */
+const canonicalize = (text: string): string =>
+  text
+    .replace(/\r\n?/gu, "\n")
+    .normalize("NFC")
+    .replace(/[ \t]+(?=\n|$)/gu, "");
+
+const expectPartsOfCanonicalText = (text: string, parts: readonly string[]): void => {
+  const canonical = canonicalize(text);
+  expect(parts.join("")).toBe(canonical);
   for (const part of parts) {
     expect(part.length).toBeGreaterThan(0);
     expect(bytes(part)).toBeLessThanOrEqual(maximumBytes);
+    // A part is stored unchanged only when it already equals its own canonical form.
+    expect(canonicalize(part)).toBe(part);
   }
 };
 
@@ -43,8 +58,7 @@ describe("parsed text splitting", () => {
       2.5 * maximumBytes,
     ]) {
       const text = line.repeat(Math.ceil(size / line.length)).slice(0, size);
-      const parts = splitParsedText(text, maximumBytes);
-      expectReassembles(text, parts);
+      expectPartsOfCanonicalText(text, splitParsedText(text, maximumBytes));
     }
   });
 
@@ -61,47 +75,97 @@ describe("parsed text splitting", () => {
     const doubled = text.repeat(2);
     const doubledParts = splitParsedText(doubled, maximumBytes);
     expect(doubledParts).toHaveLength(2);
-    expectReassembles(doubled, doubledParts);
+    expectPartsOfCanonicalText(doubled, doubledParts);
   });
 
   it("never cuts between a high and a low surrogate", () => {
     const text = `a${"😀".repeat(262_150)}\n`;
     const parts = splitParsedText(text, maximumBytes);
-    expectReassembles(text, parts);
+    expectPartsOfCanonicalText(text, parts);
     for (const part of parts) expect(loneSurrogates(part)).toBe(0);
     // Round-tripping through UTF-8 must not introduce a replacement character.
-    expect(parts.map((part) => new TextDecoder().decode(encoder.encode(part))).join("")).toBe(text);
+    expect(parts.map((part) => new TextDecoder().decode(encoder.encode(part))).join("")).toBe(
+      canonicalize(text),
+    );
     expect(parts.join("")).not.toContain("\uFFFD");
   });
 
-  it("cuts a single over-long line quickly instead of rescanning every prefix", () => {
-    const text = "x".repeat(3 * maximumBytes);
+  it("terminates when a combining mark cannot be kept with the code point before it", () => {
+    // These shapes previously looped forever: the mark back-off walked the cut back to the
+    // start of an empty part, so nothing was ever pushed and the cursor never advanced.
+    for (const text of ["a\u0301\u0301", "\u6f22\u0301", "\u0301", "\u0301\u0301\n"]) {
+      const started = Date.now();
+      const parts = splitParsedText(text, 4);
+      expect(Date.now() - started).toBeLessThan(1_000);
+      for (const part of parts) expect(bytes(part)).toBeLessThanOrEqual(4);
+      expect(parts.join("")).toBe(canonicalize(text));
+    }
+
+    const long = `a${"\u0301".repeat(600_000)}`;
     const started = Date.now();
-    const parts = splitParsedText(text, maximumBytes);
-    const elapsed = Date.now() - started;
-    expect(parts).toHaveLength(3);
-    expect(parts.every((part) => bytes(part) === maximumBytes)).toBe(true);
-    expectReassembles(text, parts);
-    expect(elapsed).toBeLessThan(2_000);
+    const parts = splitParsedText(long, maximumBytes);
+    expect(Date.now() - started).toBeLessThan(5_000);
+    expectPartsOfCanonicalText(long, parts);
   });
 
-  it("does not start a part with a combining mark", () => {
-    // 1 MiB of two-byte code points, then a base letter with a combining acute accent.
-    const text = `${"\u00e9".repeat(maximumBytes / 2)}e\u0301 tail`;
+  it("cuts a single over-long line in linear time", () => {
+    const timings: number[] = [];
+    for (const mebibytes of [1, 2, 4, 8]) {
+      const text = "x".repeat(mebibytes * maximumBytes);
+      const started = Date.now();
+      const parts = splitParsedText(text, maximumBytes);
+      timings.push(Date.now() - started);
+      expect(parts).toHaveLength(mebibytes);
+      expect(parts.every((part) => bytes(part) === maximumBytes)).toBe(true);
+      expect(parts.join("")).toBe(text);
+    }
+    // Linear growth means doubling the input roughly doubles the work; the previous
+    // implementation re-scanned the whole remaining line for each part.
+    const [one, , four, eight] = timings as [number, number, number, number];
+    expect(eight).toBeLessThan(Math.max(1_500, one * 16 + 500));
+    expect(four).toBeLessThan(Math.max(1_000, one * 8 + 300));
+  });
+
+  it("does not start a part with a combining mark even at a line boundary", () => {
+    // Fill one part to 64 bytes below the limit, then begin the next line with a mark.
+    const filler = `${"a".repeat(63)}\n`.repeat(16_383);
+    const text = `${filler}\u0301${"b".repeat(99)}\n`;
     const parts = splitParsedText(text, maximumBytes);
-    expectReassembles(text, parts);
+    expectPartsOfCanonicalText(text, parts);
     for (const part of parts) {
       const first = part.codePointAt(0) ?? 0;
-      const isCombining = /^\p{M}$/u.test(String.fromCodePoint(first));
-      expect(isCombining).toBe(false);
+      expect(/^\p{M}$/u.test(String.fromCodePoint(first))).toBe(false);
     }
+  });
+
+  it("does not end a part with spaces or tabs the engine would strip", () => {
+    const text = `${"a".repeat(maximumBytes - 8)}   tail after spaces\n`;
+    const parts = splitParsedText(text, maximumBytes);
+    expectPartsOfCanonicalText(text, parts);
+    for (const part of parts) expect(/[ \t]$/u.test(part)).toBe(false);
+  });
+
+  it("canonicalizes before splitting, so CRLF and NFC-expanding text stay legal", () => {
+    const crlf = `line one\r\nline two\r\n${"x".repeat(maximumBytes)}\r\n`;
+    const crlfParts = splitParsedText(crlf, maximumBytes);
+    expectPartsOfCanonicalText(crlf, crlfParts);
+    expect(crlfParts.join("")).not.toContain("\r");
+
+    // U+0958 has a canonical decomposition and is a composition exclusion, so NFC turns each
+    // code point into three bytes. Splitting the raw text would produce parts that the engine
+    // then refuses for exceeding the limit.
+    const expanding = "\u0958".repeat(400_000);
+    const expandingParts = splitParsedText(expanding, maximumBytes);
+    expectPartsOfCanonicalText(expanding, expandingParts);
+    expect(expandingParts.length).toBeGreaterThan(1);
+    for (const part of expandingParts) expect(bytes(part)).toBeLessThanOrEqual(maximumBytes);
   });
 
   it("still splits correctly when the limit is only a few bytes", () => {
     const text = "ab😀cd\u0301ef\ngh";
     const parts = splitParsedText(text, 4);
     for (const part of parts) expect(bytes(part)).toBeLessThanOrEqual(4);
-    expect(parts.join("")).toBe(text);
+    expect(parts.join("")).toBe(canonicalize(text));
   });
 
   it("returns no parts for empty text", () => {

--- a/packages/runtime/src/split-parsed-text.ts
+++ b/packages/runtime/src/split-parsed-text.ts
@@ -1,11 +1,17 @@
 /**
  * Splits one oversized parsed text into parts that each fit the local material byte limit.
  *
- * The split is byte-exact and deterministic: the parts are consecutive slices of the source,
- * so joining them with an empty string reproduces the source exactly, no byte is added or
- * dropped, and no part is empty. Cuts prefer a line boundary; only a single line that cannot
- * fit in one part is cut inside the line, at a Unicode code point boundary, never between a
- * high and a low surrogate and never immediately before a combining mark.
+ * The text is first canonicalized exactly the way the engine canonicalizes stored material
+ * (CRLF/CR to LF, NFC, trailing spaces and tabs before a line end removed), so a part is stored
+ * unchanged and a mid-line cut cannot create a seam the engine would rewrite. Parts are then
+ * consecutive slices of that canonical text: joining them with an empty string reproduces it,
+ * no byte is added or dropped, and no part is empty.
+ *
+ * A cut prefers a line boundary. Only a single line that cannot fit in one part is cut inside
+ * the line, at a Unicode code point boundary, never between a high and a low surrogate, never
+ * immediately before a combining mark, and never where the part would end in spaces or tabs
+ * that the engine would strip. The scan is linear in the text length, including for a single
+ * line larger than the limit.
  *
  * @param text - Rendered material text.
  * @param maximumBytes - Largest UTF-8 byte length one part may have.
@@ -13,61 +19,144 @@
  */
 export const splitParsedText = (text: string, maximumBytes: number): readonly string[] => {
   if (maximumBytes < 4) throw new Error("A part must be able to hold one code point.");
+  const canonical = text
+    .replace(/\r\n?/gu, "\n")
+    .normalize("NFC")
+    .replace(/[ \t]+(?=\n|$)/gu, "");
   const parts: string[] = [];
   let partStart = 0;
   let partBytes = 0;
   let cursor = 0;
-  const pushPart = (end: number): void => {
-    parts.push(text.slice(partStart, end));
+  const push = (end: number): void => {
+    parts.push(canonical.slice(partStart, end));
     partStart = end;
     partBytes = 0;
   };
-  while (cursor < text.length) {
-    const newline = text.indexOf("\n", cursor);
-    // A line keeps its own newline, so a cut after it loses nothing.
-    const lineEnd = newline === -1 ? text.length : newline + 1;
-    const lineBytes = utf8BytesIn(text, cursor, lineEnd);
-    if (partBytes + lineBytes <= maximumBytes) {
+  while (cursor < canonical.length) {
+    const newline = canonical.indexOf("\n", cursor);
+    const lineEnd = newline === -1 ? canonical.length : newline + 1;
+    const lineBytes = utf8BytesIn(canonical, cursor, lineEnd);
+    if (lineBytes <= maximumBytes) {
+      if (partBytes + lineBytes > maximumBytes) {
+        // Close this part on the line boundary, taking any combining marks that begin this
+        // line with it so the next part cannot start with a detached mark. The rest of the
+        // line then starts the next part, where it fits because this line fits in one part.
+        const extended = extendOverMarks(canonical, cursor, partBytes, maximumBytes);
+        push(extended);
+        cursor = extended;
+        continue;
+      }
       partBytes += lineBytes;
       cursor = lineEnd;
       continue;
     }
-    if (lineBytes > maximumBytes) {
-      // One line is larger than a whole part: fill the rest of this part by code point.
-      let end = cursor;
-      let bytes = partBytes;
+    // One line is larger than a whole part: fill the rest of this part, then chunk the line.
+    if (partBytes > 0) push(cursor);
+    let index = cursor;
+    while (index < lineEnd) {
+      let end = index;
+      let bytes = 0;
       while (end < lineEnd) {
-        const codePoint = text.codePointAt(end) ?? 0;
+        const codePoint = canonical.codePointAt(end) ?? 0;
         const width = utf8Width(codePoint);
         if (bytes + width > maximumBytes) break;
         bytes += width;
         end += codePoint > 0xffff ? 2 : 1;
       }
-      // A part must not begin with a combining mark, or the mark renders detached.
-      while (end > cursor && end < lineEnd) {
-        const next = text.codePointAt(end) ?? 0;
-        if (!COMBINING_MARK.test(String.fromCodePoint(next))) break;
-        const previousStart = previousCodePointStart(text, end, cursor);
-        bytes -= utf8Width(text.codePointAt(previousStart) ?? 0);
-        end = previousStart;
-      }
-      if (end > cursor) {
-        cursor = end;
-        partBytes = bytes;
-      }
-      // A part that is already full is flushed and the line continues in the next part.
-      if (partBytes > 0) pushPart(cursor);
-      continue;
+      if (end === index) throw new Error("A part must be able to hold one code point.");
+      const cut = trimCut(canonical, index, end, lineEnd, bytes);
+      parts.push(canonical.slice(index, cut.end));
+      index = cut.end;
     }
-    // The line fits in an empty part, so this part ends here and the line starts the next one.
-    pushPart(cursor);
+    partStart = index;
+    cursor = index;
+    partBytes = 0;
   }
-  if (partBytes > 0) parts.push(text.slice(partStart));
+  if (partBytes > 0) parts.push(canonical.slice(partStart));
   return parts;
 };
 
 /** Matches one combining mark, which must not be the first code point of a part. */
 const COMBINING_MARK = /^\p{M}$/u;
+
+/**
+ * Largest number of code points a cut may move back to avoid a seam the engine would rewrite.
+ *
+ * The bound keeps the scan linear when a pathological line is one long run of combining marks
+ * or spaces: past it the cut is taken as computed, which can leave a detached mark or a
+ * stripped space in that one place instead of scanning the whole run again for every part.
+ */
+const MAXIMUM_CUT_BACKOFF = 32;
+
+/** Matches the whitespace the engine strips at the end of a part. */
+const TRIMMED_AT_PART_END = /^[ \t]$/u;
+
+/**
+ * Moves a line-boundary cut forward over combining marks that begin the next line.
+ *
+ * @param text - Canonical text.
+ * @param cursor - Index of the next line's first code point.
+ * @param usedBytes - Bytes already in the closing part.
+ * @param maximumBytes - Part byte ceiling.
+ * @returns Index the closing part should end at.
+ */
+const extendOverMarks = (
+  text: string,
+  cursor: number,
+  usedBytes: number,
+  maximumBytes: number,
+): number => {
+  let end = cursor;
+  let bytes = usedBytes;
+  while (end < text.length) {
+    const codePoint = text.codePointAt(end) ?? 0;
+    if (!COMBINING_MARK.test(String.fromCodePoint(codePoint))) break;
+    const width = utf8Width(codePoint);
+    if (bytes + width > maximumBytes) break;
+    bytes += width;
+    end += codePoint > 0xffff ? 2 : 1;
+  }
+  return end;
+};
+
+/**
+ * Chooses where a mid-line cut ends so the stored part equals the slice.
+ *
+ * A part must not end in spaces or tabs (the engine strips them) and the next part must not
+ * begin with a combining mark, but a part always keeps at least one code point so the scan
+ * always advances.
+ *
+ * @param text - Canonical text.
+ * @param start - First index of the part.
+ * @param end - Largest index that fits the byte ceiling.
+ * @param lineEnd - Exclusive end of the line being cut.
+ * @param bytes - Byte length of the untrimmed slice.
+ * @returns The chosen end index and its byte length.
+ */
+const trimCut = (
+  text: string,
+  start: number,
+  end: number,
+  lineEnd: number,
+  bytes: number,
+): { readonly end: number; readonly bytes: number } => {
+  let trimmedEnd = end;
+  let trimmedBytes = bytes;
+  let steps = 0;
+  while (trimmedEnd < lineEnd && trimmedEnd > start && steps < MAXIMUM_CUT_BACKOFF) {
+    const next = text.codePointAt(trimmedEnd) ?? 0;
+    const previousStart = previousCodePointStart(text, trimmedEnd, start);
+    if (previousStart <= start) break;
+    const previous = text.codePointAt(previousStart) ?? 0;
+    const startsWithMark = COMBINING_MARK.test(String.fromCodePoint(next));
+    const endsWithTrimmed = TRIMMED_AT_PART_END.test(String.fromCodePoint(previous));
+    if (!startsWithMark && !endsWithTrimmed) break;
+    trimmedEnd = previousStart;
+    trimmedBytes -= utf8Width(previous);
+    steps += 1;
+  }
+  return { end: trimmedEnd, bytes: trimmedBytes };
+};
 
 /**
  * Measures the UTF-8 byte width of one code point.


### PR DESCRIPTION
## What
feat: chat-export transcripts, idempotent harvest, linear splitter

## Commits
- feat(adapters): read chat exports as transcripts
- feat(cli): make harvest idempotent and never guess between same-named people
- fix(runtime): terminate and linearize the text splitter, and harden harvest

## Stack
Stacked on `pr/07-subject-show-and-split`; the whole series ends at `distilly-work` (`0bd924e`).

## Verification
Every feature carries an author report and an independent audit in the delivery evidence folder (`host-verification/`), including screenshots and the audit verdict that drove the fixes. Gates on the top of the stack: format, lint, docs, release check, and 1163 tests.

## Real hosts
Codex, Claude Code 2.1.268, OpenClaw 2026.9.2, Hermes v0.19.0, and DSH 0.1.5-rc.1 were each exercised end to end (install, host-visible confirmation, exactly five MCP tools, person Skill install/remove, uninstall). Capacity fixtures are recorded for Codex 0.146.0, OpenClaw 2026.3.24, and Hermes v0.9.0; newer host versions run on the labelled conservative floor.

## Evidence
Author reports and screenshots (delivery evidence folder `host-verification/`):
- f5-chat-export-parsers-REPORT.md, f5-chat-export-parsers.png
- f12-f13-harvest-and-split-hardening-REPORT.md, f13-split-hardening.png, f15-round13-fixes-REPORT.md

Independent audit reports:
- round11-split-VERIFY.md, round12-harvest-idempotence-VERIFY.md, round13-split-termination-VERIFY.md