### PR TITLE
feat: version history/diff/rollback and the person Skill lifecycle

### DIFF
--- a/packages/bindings/src/dsh-binding.test.ts
+++ b/packages/bindings/src/dsh-binding.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,6 +8,7 @@ import type { HostCapabilities } from "@distilly/protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createDshHostBinding } from "./dsh/full.js";
+import { listPersonInstalls } from "./full/injector.js";
 import type { DshHostBindingOptions, HostFormPresenter } from "./protocol.js";
 
 const REPOSITORY_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
@@ -251,5 +252,64 @@ describe("DeepSeek Harness full binding", () => {
     expect(failure === undefined ? "constructed" : (failure as Error).message).toMatch(
       /dsh-mcp-client/u,
     );
+  });
+});
+
+describe("DSH person Skill root", () => {
+  it("installs a person Skill into the skills root DSH itself scans", async () => {
+    const home = await temporaryHome();
+    const binding = createDshHostBinding(await options(home));
+    const manifest = JSON.parse(
+      await readFile(join(REPOSITORY_ROOT, "plugins", "release-manifest.json"), "utf8"),
+    ) as { releaseVersion: string; canonicalSkill: { digest: `sha256_${string}` } };
+    const facet = (name: string): string =>
+      `# core.${name}\n\n## Active claims\n\n    []\n\n## Contested claims\n\n    []\n`;
+    const profile = {
+      subjectId: `subject_${"a".repeat(32)}`,
+      displayName: "Ada Lovelace",
+      versionId: `version_${"b".repeat(64)}`,
+      claims: [],
+      core: {
+        identity: facet("identity"),
+        voice: facet("voice"),
+        psyche: facet("psyche"),
+        relations: facet("relations"),
+        boundaries: facet("boundaries"),
+        texture: facet("texture"),
+        timeline: facet("timeline"),
+      },
+      domains: {},
+      rendered: "# Distilly profile\n\n## Core facets\n\nNo recorded claims.\n",
+      quality: {
+        sourceGroupingVersion: "source-groups-v1",
+        activeClaimCount: 0,
+        contestedClaimCount: 0,
+        userAssertedClaimCount: 0,
+        corroboratedClaimCount: 0,
+        sourceGroupCount: 0,
+        diversityEligibleSourceGroupCount: 0,
+        unknownSourceGroupCount: 0,
+        coveredCoreFacets: [],
+        uncoveredCoreFacets: [
+          "identity",
+          "voice",
+          "psyche",
+          "relations",
+          "boundaries",
+          "texture",
+          "timeline",
+        ],
+        maturity: "sparse",
+      },
+    };
+    const injector = binding.createInjector({ sessionId: "dsh-person", environment: "cli" });
+    const installed = await injector.install(profile as never, {});
+    expect(installed.path).toBe(join(home, "skills", installed.path.split("/").at(-1) ?? ""));
+    expect(await readdir(join(home, "skills"))).toEqual([installed.path.split("/").at(-1)]);
+    expect(await readFile(join(installed.path, "SKILL.md"), "utf8")).toContain("Ada Lovelace");
+    const listed = await listPersonInstalls("dsh" as never, home);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({ verified: true, install: { id: installed.id } });
+    void manifest;
   });
 });

--- a/packages/bindings/src/dsh/full.ts
+++ b/packages/bindings/src/dsh/full.ts
@@ -25,6 +25,8 @@ const DEFAULT_PROFILE_NAME = "distilly";
 
 /** Profile patch file DSH composes after every bundle layer. */
 const PATCH_FILE = "cordis.patch.yml";
+/** Composed profile DSH itself writes next to the patch layer. */
+const COMPOSED_CONFIG_FILE = "cordis.yml";
 
 /** Platform manifest carrier that the shared installer verifies and rewrites. */
 const PROFILE_MANIFEST = "package.json";
@@ -304,6 +306,8 @@ export const createDshHostBinding = (options: DshHostBindingOptions): HostBindin
           expectedSkillDigest: options.release.canonicalSkillDigest,
           mcpShape: () => ({}),
           preservePlatformManifestFields: true,
+          // DSH composes the profile and writes its own cordis.yml beside the layer we own.
+          hostGeneratedPaths: [COMPOSED_CONFIG_FILE],
           extraOwnedFiles: (launcherPath) =>
             new Map([
               [PATCH_FILE, patchLayer(launcherPath, clientPackage, host)],

--- a/packages/bindings/src/full-binding.test.ts
+++ b/packages/bindings/src/full-binding.test.ts
@@ -13,15 +13,17 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import type {
-  ContentDigest,
-  HostCapabilities,
-  Profile,
-  SubjectId,
-  VersionId,
+import {
+  BUILTIN_HOSTS,
+  type ContentDigest,
+  type HostCapabilities,
+  type Profile,
+  type SubjectId,
+  type VersionId,
 } from "@distilly/protocol";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
+import { listPersonInstalls } from "./full/injector.js";
 import { createClaudeCodeHostBinding } from "./claude-code/full.js";
 import { createCodexHostBinding } from "./codex/full.js";
 import { defaultHostCommandRunner } from "./full/command-runner.js";
@@ -652,5 +654,81 @@ describe("Codex full binding", () => {
     await expect(
       incompatible.doctor({ sessionId: "codex-doctor", environment: "cli" }),
     ).resolves.toMatchObject({ wireCompatible: false });
+  });
+});
+
+describe("person Skill lifecycle", () => {
+  it("updates the install Distilly owns when the same subject is distilled again", async () => {
+    const home = await temporaryHome();
+    const binding = createClaudeCodeHostBinding(sharedOptions(home));
+    const injector = binding.createInjector({ sessionId: "claude-update", environment: "cli" });
+    const first = await injector.install(PROFILE, {});
+    const skillPath = join(first.path, "SKILL.md");
+    const firstSkill = await readFile(skillPath, "utf8");
+
+    const nextVersion = {
+      ...PROFILE,
+      versionId: `version_${"c".repeat(64)}`,
+      rendered: `${PROFILE.rendered}\n\nNew evidence changed the boundaries.\n`,
+    } as typeof PROFILE;
+    const updated = await injector.install(nextVersion, {});
+
+    expect(updated.path).toBe(first.path);
+    expect(updated.versionId).toBe(nextVersion.versionId);
+    expect(updated.contentDigest).not.toBe(first.contentDigest);
+    expect(await readdir(join(home, ".claude", "skills"))).toEqual([basename(first.path)]);
+    const skill = await readFile(skillPath, "utf8");
+    expect(skill).not.toBe(firstSkill);
+    expect(skill).toContain("New evidence changed the boundaries.");
+    const manifest = JSON.parse(
+      await readFile(join(first.path, ".distilly-install.json"), "utf8"),
+    ) as { install: { versionId: string } };
+    expect(manifest.install.versionId).toBe(nextVersion.versionId);
+  });
+
+  it("keeps the Skill path stable when a display-name change moves its directory", async () => {
+    const home = await temporaryHome();
+    const binding = createClaudeCodeHostBinding(sharedOptions(home));
+    const injector = binding.createInjector({ sessionId: "claude-rename", environment: "cli" });
+    const first = await injector.install(PROFILE, {});
+    const renamed = { ...PROFILE, displayName: "Ada B. Lovelace" } as typeof PROFILE;
+    const updated = await injector.install(renamed, {});
+    expect(updated.path).toBe(first.path);
+    expect(await readdir(join(home, ".claude", "skills"))).toEqual([basename(first.path)]);
+    expect(await readFile(join(first.path, "SKILL.md"), "utf8")).toContain("Ada B. Lovelace");
+  });
+
+  it("lists verified installs and reports a modified directory instead of hiding it", async () => {
+    const home = await temporaryHome();
+    const binding = createClaudeCodeHostBinding(sharedOptions(home));
+    const injector = binding.createInjector({ sessionId: "claude-list", environment: "cli" });
+    const installed = await injector.install(PROFILE, {});
+    await mkdir(join(home, ".claude", "skills", "some-other-skill"), { recursive: true });
+    const before = await listPersonInstalls(BUILTIN_HOSTS.claudeCode, home);
+    expect(before).toHaveLength(2);
+    expect(before[0]).toMatchObject({ verified: true, install: { subjectId: SUBJECT_ID } });
+    const unverified = before[1];
+    expect(unverified?.verified).toBe(false);
+
+    await writeFile(join(installed.path, "SKILL.md"), "hand edited\n");
+    const after = await listPersonInstalls(BUILTIN_HOSTS.claudeCode, home);
+    expect(after.filter((entry) => entry.verified)).toHaveLength(0);
+    expect(after.map((entry) => entry.verified)).toEqual([false, false]);
+  });
+
+  it("refuses to replace a modified install and leaves it untouched", async () => {
+    const home = await temporaryHome();
+    const binding = createClaudeCodeHostBinding(sharedOptions(home));
+    const injector = binding.createInjector({ sessionId: "claude-modified", environment: "cli" });
+    const first = await injector.install(PROFILE, {});
+    await writeFile(join(first.path, "SKILL.md"), "hand edited\n");
+    const nextVersion = {
+      ...PROFILE,
+      versionId: `version_${"d".repeat(64)}`,
+    } as typeof PROFILE;
+    await expect(injector.install(nextVersion, {})).rejects.toMatchObject({
+      code: "storage_corrupt",
+    });
+    expect(await readFile(join(first.path, "SKILL.md"), "utf8")).toBe("hand edited\n");
   });
 });

--- a/packages/bindings/src/full/injector.ts
+++ b/packages/bindings/src/full/injector.ts
@@ -1,5 +1,15 @@
 import { createHash, randomUUID } from "node:crypto";
-import { lstat, mkdir, readFile, rename, rm, rmdir, unlink, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  rmdir,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import {
@@ -120,6 +130,8 @@ const defaultSkillsRoot = (host: HostName, homeDirectory: string): string => {
   if (host === "claude-code") return join(homeDirectory, ".claude", "skills");
   if (host === "openclaw") return join(homeDirectory, ".openclaw", "skills");
   if (host === "hermes") return join(homeDirectory, ".hermes", "skills");
+  // DSH scans its own home's skills root, so a person Skill belongs beside the integration.
+  if (host === "dsh") return join(homeDirectory, "skills");
   throw invalid(`No default Skill directory is defined for host ${host}.`);
 };
 
@@ -258,16 +270,38 @@ const installProfile = async (
     contentDigest,
   } as const;
 
-  const existing = await lstat(root).catch(() => undefined);
+  // A profile can be re-distilled after its Skill was installed. Distilly updates the install
+  // it already owns for this subject in place rather than refusing or leaving a second copy
+  // behind, and a display-name change therefore keeps the host's Skill path stable.
+  const owned =
+    options.destination === undefined
+      ? await findOwnedInstall(host, homeDirectory, profile.subjectId)
+      : undefined;
+  const destination = owned?.path ?? root;
+  const existing = await lstat(destination).catch(() => undefined);
   if (existing !== undefined) {
     if (!existing.isDirectory() || existing.isSymbolicLink()) {
       throw invalid("The person Skill destination already exists and is not a regular directory.");
     }
-    const current = await readVerifiedInstall(root, host);
+    const current = await readVerifiedInstall(destination, host);
     if (hasSameInstallIdentity(current.install, identity)) return current.install;
-    throw invalid(
-      "The person Skill destination already contains another or modified installation.",
-    );
+    if (current.install.subjectId !== profile.subjectId) {
+      throw invalid(
+        "The person Skill destination already contains another or modified installation.",
+      );
+    }
+    const replaced: InstallRef = {
+      id: personInstallId({ ...identity, path: destination }),
+      ...identity,
+      path: destination,
+      installedAt: isoDateTimeSchema.parse(now().toISOString()),
+    };
+    await replaceInstall(destination, homeDirectory, host, skill, {
+      schemaVersion: 1,
+      install: replaced,
+      files: [{ path: SKILL_FILE, contentDigest }],
+    });
+    return replaced;
   }
 
   const install: InstallRef = {
@@ -297,6 +331,118 @@ const installProfile = async (
     throw error;
   }
   return install;
+};
+
+/**
+ * Replaces one verified person Skill with a new version without a window where neither exists.
+ *
+ * The old Skill is moved aside first and restored if the new one cannot be moved into place, so
+ * a failure leaves the host with exactly the Skill it had before. Only a verified install is
+ * ever replaced: modified or foreign content is never deleted by Distilly.
+ *
+ * @param destination - Absolute Skill directory to replace.
+ * @param homeDirectory - Host home owning the transaction directory.
+ * @param host - Host the Skill belongs to.
+ * @param skill - New SKILL.md content.
+ * @param manifest - New install manifest.
+ */
+const replaceInstall = async (
+  destination: string,
+  homeDirectory: string,
+  host: HostName,
+  skill: string,
+  manifest: PersonInstallManifest,
+): Promise<void> => {
+  const transactionRoot = join(homeDirectory, ".distilly", "host-install");
+  await mkdir(transactionRoot, { recursive: true });
+  const staging = join(transactionRoot, `${host}-person-${randomUUID()}`);
+  const backup = join(transactionRoot, `${host}-person-previous-${randomUUID()}`);
+  await mkdir(staging);
+  await writeFile(join(staging, SKILL_FILE), skill, { mode: 0o644 });
+  await writeFile(join(staging, INSTALL_MANIFEST), `${canonicalJson(manifest)}\n`, { mode: 0o600 });
+  let movedAside = false;
+  try {
+    await rename(destination, backup);
+    movedAside = true;
+    await rename(staging, destination);
+  } catch (error) {
+    if (movedAside) await rename(backup, destination).catch(() => undefined);
+    await rm(staging, { recursive: true, force: true });
+    throw error;
+  }
+  await rm(backup, { recursive: true, force: true });
+};
+
+/**
+ * Finds the person Skill Distilly already installed for one subject under a host's skills root.
+ *
+ * @param host - Host whose skills root is scanned.
+ * @param homeDirectory - Host home directory.
+ * @param subjectId - Subject the Skill must belong to.
+ * @returns The verified install, or undefined when no readable install matches.
+ */
+const findOwnedInstall = async (
+  host: HostName,
+  homeDirectory: string,
+  subjectId: string,
+): Promise<InstallRef | undefined> => {
+  const installs = await listPersonInstalls(host, homeDirectory);
+  const match = installs.find(
+    (entry): entry is Extract<PersonInstallSummary, { verified: true }> =>
+      entry.verified && entry.install.subjectId === subjectId,
+  );
+  return match?.install;
+};
+
+/** One entry under a host's skills root that looks like a Distilly person Skill. */
+export type PersonInstallSummary =
+  | { readonly verified: true; readonly install: InstallRef }
+  | {
+      readonly verified: false;
+      readonly path: string;
+      readonly host: HostName;
+      /** Why the directory could not be verified as a Distilly install. */
+      readonly reason: string;
+    };
+
+/**
+ * Lists every person Skill installed for one host, verified ones first.
+ *
+ * A directory that cannot be verified is reported instead of hidden: it is either a modified
+ * Distilly Skill (which Distilly refuses to overwrite or delete) or another tool's Skill that
+ * happens to sit in the same root.
+ *
+ * @param host - Host whose skills root is scanned.
+ * @param homeDirectory - Host home directory.
+ * @returns Deterministically ordered install summaries.
+ */
+export const listPersonInstalls = async (
+  host: HostName,
+  homeDirectory: string,
+): Promise<readonly PersonInstallSummary[]> => {
+  const root = defaultSkillsRoot(host, homeDirectory);
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  const summaries: PersonInstallSummary[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    const path = join(root, entry.name);
+    try {
+      const manifest = await readVerifiedInstall(path, host);
+      summaries.push({ verified: true, install: manifest.install });
+    } catch (error) {
+      summaries.push({
+        verified: false,
+        path,
+        host,
+        reason: error instanceof Error ? error.message : "The install could not be verified.",
+      });
+    }
+  }
+  return summaries.sort((left, right) => {
+    const leftPath = left.verified ? left.install.path : left.path;
+    const rightPath = right.verified ? right.install.path : right.path;
+    return compareUtf8(leftPath, rightPath);
+  });
 };
 
 const resolveDestination = (destination: string): string => {

--- a/packages/bindings/src/full/plugin-tree.ts
+++ b/packages/bindings/src/full/plugin-tree.ts
@@ -38,6 +38,14 @@ interface PluginOwnershipManifest {
   readonly runtimeVersion: string;
   readonly launcherPath: string;
   readonly files: readonly OwnedFile[];
+  /**
+   * Root-relative paths the host itself writes inside the plugin root.
+   *
+   * DSH composes a profile and writes `cordis.yml` beside the layer Distilly owns. Such a file
+   * is expected, is never treated as ours, and never fails verification; anything outside this
+   * list still fails as an unowned file.
+   */
+  readonly hostGeneratedPaths?: readonly string[];
 }
 
 interface PreparedPlugin {
@@ -70,6 +78,13 @@ export interface PluginTreeOptions {
    * manifest into the minimal name/version/pointer carrier.
    */
   readonly preservePlatformManifestFields?: boolean;
+  /**
+   * Host-generated paths that may appear inside the plugin root after the host boots.
+   *
+   * They are recorded in the ownership manifest so verification accepts exactly the files this
+   * host is known to write, and removal deletes them with the tree it owns.
+   */
+  readonly hostGeneratedPaths?: readonly string[];
 }
 
 const fail = (message: string, fieldPath?: string): DistillyError =>
@@ -235,6 +250,14 @@ const preparePlugin = async (
     files.set(safeRelativePath(path), bytes);
   }
 
+  const hostGeneratedPaths = (options.hostGeneratedPaths ?? []).map((path) =>
+    safeRelativePath(path),
+  );
+  for (const path of hostGeneratedPaths) {
+    if (files.has(path) || path === OWNERSHIP_FILE) {
+      throw fail("A host-generated plugin path collides with an owned file.", "hostGeneratedPaths");
+    }
+  }
   const ownership: PluginOwnershipManifest = {
     schemaVersion: 1,
     host: options.host,
@@ -243,6 +266,7 @@ const preparePlugin = async (
     files: [...files.entries()]
       .map(([path, bytes]) => ({ path, contentDigest: sha256(bytes) }))
       .sort((left, right) => compareUtf8(left.path, right.path)),
+    ...(hostGeneratedPaths.length === 0 ? {} : { hostGeneratedPaths }),
   };
   files.set(OWNERSHIP_FILE, Buffer.from(`${canonicalJson(ownership)}\n`, "utf8"));
   return { files };
@@ -291,12 +315,30 @@ const parseOwnership = (bytes: Uint8Array): PluginOwnershipManifest => {
   if (unique.size !== files.length || unique.has(OWNERSHIP_FILE)) {
     throw corrupt("The installed plugin ownership manifest contains duplicate paths.");
   }
+  const hostGeneratedPaths =
+    value.hostGeneratedPaths === undefined
+      ? []
+      : Array.isArray(value.hostGeneratedPaths)
+        ? value.hostGeneratedPaths.map((entry) => {
+            if (typeof entry !== "string") {
+              throw corrupt("The installed plugin ownership manifest is invalid.");
+            }
+            const path = safeRelativePath(entry);
+            if (path === OWNERSHIP_FILE || files.some((file) => file.path === path)) {
+              throw corrupt("The installed plugin ownership manifest is invalid.");
+            }
+            return path;
+          })
+        : (() => {
+            throw corrupt("The installed plugin ownership manifest is invalid.");
+          })();
   return {
     schemaVersion: 1,
     host: value.host as HostName,
     runtimeVersion: value.runtimeVersion,
     launcherPath: value.launcherPath,
     files,
+    ...(hostGeneratedPaths.length === 0 ? {} : { hostGeneratedPaths }),
   };
 };
 
@@ -346,11 +388,14 @@ const readVerifiedPluginTree = async (
   }
   await verifyOwnedFiles(pluginRoot, ownership);
   const actualFiles = await walkRegularFiles(pluginRoot);
-  const expectedFiles = new Set([OWNERSHIP_FILE, ...ownership.files.map((file) => file.path)]);
-  if (
-    actualFiles.size !== expectedFiles.size ||
-    [...actualFiles.keys()].some((path) => !expectedFiles.has(path))
-  ) {
+  // Owned files must all be present (checked above). A host-generated file is allowed to be
+  // present, but is not required: a fresh install has none until the host boots once.
+  const allowedFiles = new Set([
+    OWNERSHIP_FILE,
+    ...ownership.files.map((file) => file.path),
+    ...(ownership.hostGeneratedPaths ?? []),
+  ]);
+  if ([...actualFiles.keys()].some((path) => !allowedFiles.has(path))) {
     throw corrupt("The installed plugin contains files not owned by Distilly.");
   }
   return ownership;

--- a/packages/bindings/src/index.ts
+++ b/packages/bindings/src/index.ts
@@ -8,7 +8,9 @@ export { createHermesCapabilityBinding } from "./hermes/capability.js";
 export { createHermesHostBinding } from "./hermes/full.js";
 export { createOpenClawCapabilityBinding } from "./openclaw/capability.js";
 export { createOpenClawHostBinding } from "./openclaw/full.js";
+export { listPersonInstalls } from "./full/injector.js";
 export { HostRegistry } from "./registry.js";
+export type { PersonInstallSummary } from "./full/injector.js";
 export type {
   HostActionRegistration,
   HostAnswer,

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -154,6 +154,64 @@ describe("Developer Preview CLI host boundary", () => {
     expect(stdout).toEqual([]);
   });
 
+  it("requires a subject and the right flags for the version commands", async () => {
+    const stdout: string[] = [];
+    const io = {
+      stdout: { write: (value: string) => stdout.push(value) },
+      stderr: { write: (value: string) => value },
+    };
+    for (const command of ["versions", "diff", "rollback"]) {
+      await expect(runPreviewCli([command, "--host", "codex"], environment, io)).rejects.toThrow(
+        "This command requires a subject id or display name, then --host <host>.",
+      );
+      await expect(
+        runPreviewCli([command, `subject_${"a".repeat(32)}`], environment, io),
+      ).rejects.toThrow("This command requires --host.");
+    }
+    await expect(
+      runPreviewCli(
+        ["versions", `subject_${"a".repeat(32)}`, "--host", "codex", "--nope", "1"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("Unknown versions option: --nope.");
+    await expect(
+      runPreviewCli(
+        ["diff", `subject_${"a".repeat(32)}`, "--host", "codex", "--reason", "x"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("Unknown diff option: --reason.");
+    await expect(
+      runPreviewCli(
+        ["rollback", `subject_${"a".repeat(32)}`, "--host", "codex", "--from", "x"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("Unknown rollback option: --from.");
+    await expect(
+      runPreviewCli(
+        ["versions", `subject_${"a".repeat(32)}`, "--host", "codex", "--limit", "0"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("--limit must be positive.");
+    expect(stdout).toEqual([]);
+  });
+
+  it("documents the version commands", async () => {
+    const stdout: string[] = [];
+    await expect(
+      runPreviewCli(["--help"], environment, {
+        stdout: { write: (value: string) => stdout.push(value) },
+        stderr: { write: (value: string) => value },
+      }),
+    ).resolves.toBe(0);
+    expect(stdout.join("")).toContain("distilly versions <subject-id|display-name> --host <host>");
+    expect(stdout.join("")).toContain("distilly diff <subject-id|display-name> --host <host>");
+    expect(stdout.join("")).toContain("distilly rollback <subject-id|display-name> --host <host>");
+  });
+
   it("documents the person Skill lifecycle commands", async () => {
     const stdout: string[] = [];
     await expect(

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -41,6 +41,12 @@ import {
   looksLikeSubjectId,
 } from "./show.js";
 import {
+  describeProfileDiff,
+  describeVersions,
+  resolveVersionArgument,
+  statusLabel,
+} from "./versions.js";
+import {
   PREVIEW_PANEL_ASSETS,
   PREVIEW_PLUGIN_SOURCES,
   PREVIEW_RUNTIME_MANIFEST,
@@ -778,6 +784,207 @@ const runRemove = async (
   }
 };
 
+/**
+ * Reads a version id argument plus optional flags shared by the version commands.
+ *
+ * @param rest - Arguments after the subject.
+ * @param options - Which flags this command accepts.
+ * @param options.withFrom - Whether this command accepts --from.
+ * @param options.withReason - Whether this command accepts --reason.
+ * @returns Parsed flags.
+ */
+const versionFlags = (
+  rest: readonly string[],
+  options: { readonly withFrom?: boolean; readonly withReason?: boolean },
+): {
+  readonly host?: string;
+  readonly to?: string;
+  readonly from?: string;
+  readonly reason?: string;
+  readonly limit?: number;
+  readonly cursor?: string;
+  readonly asJson: boolean;
+} => {
+  const parsed: {
+    host?: string;
+    to?: string;
+    from?: string;
+    reason?: string;
+    limit?: number;
+    cursor?: string;
+    asJson: boolean;
+  } = { asJson: false };
+  for (let index = 0; index < rest.length; index += 1) {
+    const flag = rest[index];
+    if (flag === "--json") {
+      parsed.asJson = true;
+      continue;
+    }
+    const value = rest[index + 1];
+    if (value === undefined) throw new Error(`Missing value for ${String(flag)}.`);
+    if (flag === "--host") parsed.host = value;
+    else if (flag === "--to") parsed.to = value;
+    else if (flag === "--from" && options.withFrom === true) parsed.from = value;
+    else if (flag === "--reason" && options.withReason === true) parsed.reason = value;
+    else if (flag === "--cursor") parsed.cursor = value;
+    else if (flag === "--limit") {
+      const limit = Number.parseInt(value, 10);
+      if (!Number.isSafeInteger(limit) || limit <= 0) throw new Error("--limit must be positive.");
+      parsed.limit = limit;
+    } else {
+      throw new Error(
+        `Unknown ${options.withFrom === true ? "diff" : options.withReason === true ? "rollback" : "versions"} option: ${String(flag)}.`,
+      );
+    }
+    index += 1;
+  }
+  return parsed;
+};
+
+/** One resolved subject, host, and open application shared by the version commands. */
+interface VersionCommandTarget {
+  readonly application: Awaited<ReturnType<typeof openApplication>>;
+  readonly subject: SubjectSummary;
+  readonly host: HostName;
+}
+
+/**
+ * Opens the local application and resolves the subject named on the command line.
+ *
+ * @param args - Subject id or display name plus flags.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ * @param options - Which flags the calling command accepts.
+ * @param options.withFrom - Whether this command accepts --from.
+ * @param options.withReason - Whether this command accepts --reason.
+ * @returns The open application, resolved subject, and host.
+ */
+const openVersionTarget = async (
+  args: readonly string[],
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+  options: { readonly withFrom?: boolean; readonly withReason?: boolean },
+): Promise<{
+  readonly target: VersionCommandTarget;
+  readonly flags: ReturnType<typeof versionFlags>;
+}> => {
+  const [subjectArgument, ...rest] = args;
+  if (
+    subjectArgument === undefined ||
+    subjectArgument.startsWith("--") ||
+    subjectArgument.trim().length === 0
+  ) {
+    throw new Error("This command requires a subject id or display name, then --host <host>.");
+  }
+  const flags = versionFlags(rest, options);
+  if (flags.host === undefined) throw new Error("This command requires --host.");
+  const host = parseHost(flags.host);
+  const application = await openApplication(host, environment);
+  try {
+    const subject = await resolveSubjectArgument(application.distilly, subjectArgument, io);
+    return { target: { application, subject, host }, flags };
+  } catch (error) {
+    await application.close();
+    throw error;
+  }
+};
+
+/**
+ * Prints one subject's version history.
+ *
+ * @param args - Subject, --host, and optional paging flags.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ */
+const runVersions = async (
+  args: readonly string[],
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<void> => {
+  const { target, flags } = await openVersionTarget(args, environment, io, {});
+  try {
+    const page = await target.application.distilly.person(target.subject.id).versions({
+      ...(flags.limit === undefined ? {} : { limit: flags.limit }),
+      ...(flags.cursor === undefined ? {} : { cursor: flags.cursor }),
+    });
+    if (flags.asJson) {
+      io.stdout.write(`${JSON.stringify(page, undefined, 2)}\n`);
+      return;
+    }
+    io.stdout.write(`${describeVersions(page, target.subject.displayName).join("\n")}\n`);
+  } finally {
+    await target.application.close();
+  }
+};
+
+/**
+ * Prints the semantic diff between two versions of one subject.
+ *
+ * @param args - Subject, --host, --from, and --to.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ */
+const runDiff = async (
+  args: readonly string[],
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<void> => {
+  const { target, flags } = await openVersionTarget(args, environment, io, { withFrom: true });
+  try {
+    if (flags.from === undefined || flags.to === undefined) {
+      throw new Error("This command requires --from <version> and --to <version>.");
+    }
+    const person = target.application.distilly.person(target.subject.id);
+    const history = await person.versions({ limit: 200 });
+    const before = resolveVersionArgument(history.items, flags.from);
+    const after = resolveVersionArgument(history.items, flags.to);
+    const diff = await person.diff(before.id, after.id);
+    if (flags.asJson) {
+      io.stdout.write(
+        `${JSON.stringify({ before: before.id, after: after.id, diff }, undefined, 2)}\n`,
+      );
+      return;
+    }
+    io.stdout.write(
+      `${target.subject.displayName}: ${before.id} -> ${after.id}\n${describeProfileDiff(diff).join("\n")}\n`,
+    );
+  } finally {
+    await target.application.close();
+  }
+};
+
+/**
+ * Restores an earlier version as a new current version, keeping every version immutable.
+ *
+ * @param args - Subject, --host, --to, and optional --reason.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ */
+const runRollback = async (
+  args: readonly string[],
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<void> => {
+  const { target, flags } = await openVersionTarget(args, environment, io, { withReason: true });
+  try {
+    if (flags.to === undefined) throw new Error("This command requires --to <version>.");
+    const person = target.application.distilly.person(target.subject.id);
+    const history = await person.versions({ limit: 200 });
+    const target_ = resolveVersionArgument(history.items, flags.to);
+    if (target_.status === "current") {
+      io.stdout.write(`${target_.id} is already the current version; nothing to roll back.\n`);
+      return;
+    }
+    const reason = flags.reason ?? `User rolled back to ${target_.id} from the distilly CLI.`;
+    const rolled = await person.rollback({ versionId: target_.id, reason });
+    io.stdout.write(
+      `Rolled ${target.subject.displayName} back to ${target_.id}.\nNew current version: ${rolled.id} (${statusLabel(rolled.status)}).\nReason recorded: ${reason}\n`,
+    );
+  } finally {
+    await target.application.close();
+  }
+};
+
 const help = `Distilly Developer Preview
 
 Usage:
@@ -785,6 +992,9 @@ Usage:
   distilly setup --host claude-code|openclaw|hermes|dsh [--allow-unverified-host]
   distilly doctor [--host <host>]
   distilly install <subject-id|display-name> --host <host>
+  distilly versions <subject-id|display-name> --host <host> [--limit <n>] [--cursor <cursor>] [--json]
+  distilly diff <subject-id|display-name> --host <host> --from <version> --to <version> [--json]
+  distilly rollback <subject-id|display-name> --host <host> --to <version> [--reason <text>]
   distilly personas --host <host> [--json]
   distilly remove <subject-id|display-name> --host <host>
   distilly uninstall --host <host>
@@ -863,6 +1073,18 @@ export const runPreviewCli = async (
     } finally {
       await application.close();
     }
+    return 0;
+  }
+  if (command === "versions") {
+    await runVersions(args, environment, io);
+    return 0;
+  }
+  if (command === "diff") {
+    await runDiff(args, environment, io);
+    return 0;
+  }
+  if (command === "rollback") {
+    await runRollback(args, environment, io);
     return 0;
   }
   if (command === "personas") {

--- a/packages/cli/src/versions.test.ts
+++ b/packages/cli/src/versions.test.ts
@@ -1,0 +1,169 @@
+import type {
+  Claim,
+  FacetPath,
+  ProfileDiff,
+  QualitySummary,
+  VersionSummary,
+} from "@distilly/protocol";
+import { describe, expect, it } from "vitest";
+
+import {
+  describeProfileDiff,
+  describeVersion,
+  describeVersions,
+  resolveVersionArgument,
+} from "./versions.js";
+
+const quality = (activeClaimCount: number): QualitySummary =>
+  ({
+    sourceGroupingVersion: "source-groups-v1",
+    activeClaimCount,
+    contestedClaimCount: 0,
+    userAssertedClaimCount: 0,
+    corroboratedClaimCount: 0,
+    sourceGroupCount: 1,
+    diversityEligibleSourceGroupCount: 1,
+    unknownSourceGroupCount: 0,
+    coveredCoreFacets: ["identity"],
+    uncoveredCoreFacets: ["voice"],
+    maturity: "sparse",
+  }) as unknown as QualitySummary;
+
+const version = (
+  id: string,
+  status: VersionSummary["status"],
+  generation: number,
+  createdAt: string,
+  activeClaimCount = 1,
+): VersionSummary =>
+  ({
+    id: `version_${id.repeat(64)}`,
+    subjectId: `subject_${"a".repeat(32)}`,
+    generation,
+    materialSetHash: `set_sha256_${"b".repeat(64)}`,
+    creation: {
+      kind: "host_distill",
+      briefContractDigest: `bcd_${"c".repeat(64)}`,
+      promptVersion: "v1",
+      draftSchemaVersion: 1,
+    },
+    status,
+    actor: { kind: "sdk", id: "test" },
+    quality: quality(activeClaimCount),
+    createdAt,
+  }) as unknown as VersionSummary;
+
+const claim = (text: string, facet = "identity"): Claim =>
+  ({
+    id: `claim_${"d".repeat(64)}`,
+    facet: facet as FacetPath,
+    text,
+    evidence: [],
+    status: "active",
+    strength: "single_source",
+    observedIn: [],
+    createdIn: `version_${"e".repeat(64)}`,
+  }) as unknown as Claim;
+
+describe("version history rendering", () => {
+  it("prints one copyable line per version and names the current one", () => {
+    const current = version("a", "current", 2, "2026-09-10T22:40:04.437Z", 2);
+    const historical = version("b", "historical", 1, "2026-09-10T22:40:02.966Z");
+    const lines = describeVersions({ items: [current, historical] }, "Ada");
+    expect(lines[0]).toBe("Ada: 2 version(s), newest first.");
+    expect(lines[1]).toContain(current.id);
+    expect(lines[1]).toContain("current");
+    expect(lines[1]).toContain("2 active claim(s)");
+    expect(lines[2]).toContain("historical");
+    expect(lines.join("\n")).not.toContain("No version is current right now");
+  });
+
+  it("says when nothing is current because a candidate waits for review", () => {
+    const suspended = version("a", "suspended", 2, "2026-09-10T22:40:05.751Z");
+    const historical = version("b", "historical", 1, "2026-09-10T22:40:04.437Z");
+    const lines = describeVersions({ items: [suspended, historical] }, "Ada");
+    expect(lines.join("\n")).toContain("No version is current right now");
+  });
+
+  it("says a subject has no version yet instead of printing an empty table", () => {
+    const lines = describeVersions({ items: [] }, "Ada");
+    expect(lines.join("\n")).toContain("Ada has no committed version yet.");
+  });
+
+  it("reports paging and how to continue", () => {
+    const page = {
+      items: [version("a", "current", 1, "2026-09-10T22:40:02.966Z")],
+      nextCursor: "cursor-2",
+    };
+    expect(describeVersions(page, "Ada").join("\n")).toContain("--cursor cursor-2");
+  });
+
+  it("labels how each version was created", () => {
+    const rolled = {
+      ...version("a", "current", 1, "2026-09-10T22:40:02.966Z"),
+      creation: { kind: "rollback", targetVersionId: `version_${"f".repeat(64)}` },
+    } as unknown as VersionSummary;
+    const line = describeVersion(rolled);
+    expect(line).toContain("rollback to version_ffffff…");
+  });
+});
+
+describe("profile diff rendering", () => {
+  const diff = (overrides: Partial<ProfileDiff> = {}): ProfileDiff =>
+    ({
+      added: [claim("Also asks what breaks second before shipping.")],
+      removed: [],
+      changed: [],
+      changedFacets: ["identity"],
+      beforeQuality: quality(1),
+      afterQuality: quality(2),
+      ...overrides,
+    }) as ProfileDiff;
+
+  it("shows counts, facet, quality movement, and each added claim", () => {
+    const text = describeProfileDiff(diff()).join("\n");
+    expect(text).toContain("Added 1, removed 0, changed 0.");
+    expect(text).toContain("Changed facets: identity");
+    expect(text).toContain("Claims: 1 -> 2 active");
+    expect(text).toContain("+ [identity] Also asks what breaks second before shipping.");
+  });
+
+  it("shows removed and changed claims with both texts", () => {
+    const text = describeProfileDiff(
+      diff({
+        added: [],
+        removed: [claim("Old boundary rule.")],
+        changed: [
+          { before: claim("Speaks in long paragraphs."), after: claim("Speaks in short lists.") },
+        ],
+      }),
+    ).join("\n");
+    expect(text).toContain("- [identity] Old boundary rule.");
+    expect(text).toContain("~ [identity] Speaks in long paragraphs.");
+    expect(text).toContain("-> Speaks in short lists.");
+  });
+
+  it("says when only metadata differs", () => {
+    const text = describeProfileDiff(diff({ added: [], removed: [], changed: [] })).join("\n");
+    expect(text).toContain("The two versions carry the same claims");
+  });
+});
+
+describe("version argument resolution", () => {
+  const versions = [
+    version("a", "current", 2, "2026-09-10T22:40:04.437Z"),
+    version("b", "historical", 1, "2026-09-10T22:40:02.966Z"),
+  ];
+
+  it("accepts a full id and a unique prefix", () => {
+    expect(resolveVersionArgument(versions, versions[0]!.id).id).toBe(versions[0]!.id);
+    expect(resolveVersionArgument(versions, "version_aaaa").id).toBe(versions[0]!.id);
+  });
+
+  it("refuses an unknown or ambiguous prefix instead of picking one", () => {
+    expect(() => resolveVersionArgument(versions, "version_zzz")).toThrow(
+      'No version matches "version_zzz" for this subject.',
+    );
+    expect(() => resolveVersionArgument(versions, "version_")).toThrow("matches 2 versions");
+  });
+});

--- a/packages/cli/src/versions.ts
+++ b/packages/cli/src/versions.ts
@@ -1,0 +1,163 @@
+import type {
+  Claim,
+  ProfileDiff,
+  VersionPage,
+  VersionStatus,
+  VersionSummary,
+} from "@distilly/protocol";
+
+/**
+ * Names how one version came to exist.
+ *
+ * @param version - Version summary from the engine.
+ * @returns A short human label.
+ */
+const creationLabel = (version: VersionSummary): string => {
+  if (version.creation.kind === "host_distill") return "distilled by a host";
+  if (version.creation.kind === "correction") return "user correction";
+  if (version.creation.kind === "rollback") {
+    return `rollback to ${version.creation.targetVersionId.slice(0, 14)}…`;
+  }
+  if (version.creation.kind === "bundle_import") return "imported bundle";
+  return "renderer only";
+};
+
+/**
+ * Renders one stable line for a version, including the id a user must copy to roll back.
+ *
+ * @param version - Version summary from the engine.
+ * @returns One line naming time, id, status, size, and origin.
+ */
+export const describeVersion = (version: VersionSummary): string =>
+  `${version.createdAt}  ${version.id}  ${version.status.padEnd(10)} gen ${String(version.generation)}  ${version.quality.maturity}  ${String(version.quality.activeClaimCount)} active claim(s)  ${creationLabel(version)}`;
+
+/**
+ * Renders a paged version history, warning when the current version is not the newest one.
+ *
+ * @param page - One page of versions in engine order.
+ * @param subjectName - Display name, so the report says whose history this is.
+ * @returns Stable report lines.
+ */
+export const describeVersions = (page: VersionPage, subjectName: string): readonly string[] => {
+  if (page.items.length === 0) {
+    return [
+      `${subjectName} has no committed version yet.`,
+      "Harvest material and let a host distill it first.",
+    ];
+  }
+  const lines = [`${subjectName}: ${String(page.items.length)} version(s), newest first.`];
+  for (const version of page.items) lines.push(`  ${describeVersion(version)}`);
+  const current = page.items.find((version) => version.status === "current");
+  if (current === undefined) {
+    lines.push(
+      "",
+      "No version is current right now: every listed version is historical or rejected, which happens while a candidate waits for review.",
+    );
+  }
+  if (page.nextCursor !== undefined) {
+    lines.push("", `More versions remain; repeat with --cursor ${page.nextCursor}.`);
+  }
+  return lines;
+};
+
+/**
+ * Summarizes quality movement between two versions.
+ *
+ * @param diff - Engine-derived profile diff.
+ * @returns Stable report lines.
+ */
+const facetSummary = (diff: ProfileDiff): readonly string[] => {
+  const lines: string[] = [];
+  if (diff.changedFacets.length > 0) {
+    lines.push(`Changed facets: ${diff.changedFacets.join(", ")}`);
+  }
+  const before = diff.beforeQuality;
+  const after = diff.afterQuality;
+  lines.push(
+    `Maturity: ${before?.maturity ?? "unknown"} -> ${after.maturity}`,
+    `Claims: ${String(before?.activeClaimCount ?? 0)} -> ${String(after.activeClaimCount)} active, ${String(before?.contestedClaimCount ?? 0)} -> ${String(after.contestedClaimCount)} contested`,
+    `Covered core facets: ${String(before?.coveredCoreFacets.length ?? 0)} -> ${String(after.coveredCoreFacets.length)}`,
+  );
+  return lines;
+};
+
+/**
+ * Renders one claim as a prefixed line.
+ *
+ * @param prefix - Marker such as "+" or "-".
+ * @param claim - Claim to render.
+ * @returns One report line.
+ */
+const claimLine = (prefix: string, claim: Claim): string =>
+  `  ${prefix} [${claim.facet}] ${claim.text}`;
+
+/**
+ * Renders a semantic diff between two versions, so a bad re-distill is visible before rollback.
+ *
+ * @param diff - Engine-derived profile diff.
+ * @returns Stable report lines.
+ */
+export const describeProfileDiff = (diff: ProfileDiff): readonly string[] => {
+  const lines = [
+    `Added ${String(diff.added.length)}, removed ${String(diff.removed.length)}, changed ${String(diff.changed.length)}.`,
+    "",
+    ...facetSummary(diff),
+  ];
+  if (diff.added.length > 0) {
+    lines.push("", "Added claims:");
+    for (const claim of diff.added) lines.push(claimLine("+", claim));
+  }
+  if (diff.removed.length > 0) {
+    lines.push("", "Removed claims:");
+    for (const claim of diff.removed) lines.push(claimLine("-", claim));
+  }
+  if (diff.changed.length > 0) {
+    lines.push("", "Changed claims:");
+    for (const change of diff.changed) {
+      lines.push(`  ~ [${change.after.facet}] ${change.before.text}`);
+      lines.push(`      -> ${change.after.text}`);
+    }
+  }
+  if (diff.added.length + diff.removed.length + diff.changed.length === 0) {
+    lines.push("", "The two versions carry the same claims; only metadata differs.");
+  }
+  return lines;
+};
+
+/**
+ * Finds the version a user meant by an id or a unique id prefix.
+ *
+ * A full 64-hex id is unusable to retype, so commands accept a unique prefix and this resolves
+ * it against the subject's own history; an ambiguous prefix lists every match instead of
+ * picking one.
+ *
+ * @param versions - Versions of one subject.
+ * @param argument - Full version id or a unique prefix.
+ * @returns The matching version.
+ */
+export const resolveVersionArgument = (
+  versions: readonly VersionSummary[],
+  argument: string,
+): VersionSummary => {
+  const exact = versions.find((version) => version.id === argument);
+  if (exact !== undefined) return exact;
+  const matches = versions.filter((version) => version.id.startsWith(argument));
+  if (matches.length === 1) {
+    const [match] = matches;
+    if (match !== undefined) return match;
+  }
+  if (matches.length === 0) {
+    throw new Error(`No version matches "${argument}" for this subject.`);
+  }
+  throw new Error(
+    `"${argument}" matches ${String(matches.length)} versions: ${matches.map((version) => version.id).join(", ")}`,
+  );
+};
+
+/**
+ * Names one version status for a success message.
+ *
+ * @param status - Engine version status.
+ * @returns The status text.
+ */
+export const statusLabel = (status: VersionStatus): string => status;


### PR DESCRIPTION
## What
feat: version history/diff/rollback and the person Skill lifecycle

## Commits
- feat(cli): show version history, diff it, and roll back
- feat(bindings): complete the person Skill lifecycle

## Stack
Stacked on `pr/08-chat-exports-and-idempotence`; the whole series ends at `distilly-work` (`0bd924e`).

## Verification
Every feature carries an author report and an independent audit in the delivery evidence folder (`host-verification/`), including screenshots and the audit verdict that drove the fixes. Gates on the top of the stack: format, lint, docs, release check, and 1163 tests.

## Real hosts
Codex, Claude Code 2.1.268, OpenClaw 2026.9.2, Hermes v0.19.0, and DSH 0.1.5-rc.1 were each exercised end to end (install, host-visible confirmation, exactly five MCP tools, person Skill install/remove, uninstall). Capacity fixtures are recorded for Codex 0.146.0, OpenClaw 2026.3.24, and Hermes v0.9.0; newer host versions run on the labelled conservative floor.

## Evidence
Author reports and screenshots (delivery evidence folder `host-verification/`):
- f8-version-rollback.png
- f9-person-skill-lifecycle-REPORT.md, f9-person-skill-lifecycle.png

Independent audit reports:
- round14-dsh-and-splitter-VERIFY.md (person Skill lifecycle), round17-parsers-and-versions-VERIFY.md (version commands)