### PR TITLE
fix/feat: real DSH home, linear canonicalization, legacy Skill import

### DIFF
--- a/packages/cli/src/harvest.test.ts
+++ b/packages/cli/src/harvest.test.ts
@@ -5,7 +5,12 @@ import { join } from "node:path";
 import { DistillyError } from "@distilly/protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { describeHarvestSelection, recordBudgetExceeded, selectHarvestFiles } from "./harvest.js";
+import {
+  describeHarvestSelection,
+  describeSkippedEntries,
+  recordBudgetExceeded,
+  selectHarvestFiles,
+} from "./harvest.js";
 
 const temporaryRoots: string[] = [];
 
@@ -119,6 +124,27 @@ describe("directory harvest selection", () => {
 
     expect(lines[0]).toBe("Selected 1 file(s) from 1 director(ies).");
     expect(lines.slice(1)).toEqual(["  skipped credential: 1", "  skipped unsupported-format: 1"]);
+  });
+});
+
+describe("skip details", () => {
+  it("keeps the path and reason of every skipped entry for reporting", async () => {
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "keep.md"), "# keep\n");
+    await writeFile(join(root, "credentials.json"), "TOKEN=1\n");
+    await writeFile(join(root, ".hidden.md"), "# hidden\n");
+    await writeFile(join(root, "clip.mp4"), "binary\n");
+    const selection = await selectHarvestFiles(root);
+    expect(selection.files.map((file) => file.pathLabel)).toEqual(["keep.md"]);
+    const skipped = selection.skippedEntries.map(
+      (entry) => `${entry.relativePath}:${entry.reason}`,
+    );
+    expect(skipped).toContain("credentials.json:credential");
+    expect(skipped).toContain(".hidden.md:hidden");
+    expect(skipped).toContain("clip.mp4:unsupported-format");
+    const lines = describeSkippedEntries(selection);
+    expect(lines.join("\n")).toContain("skipped credentials.json: credential");
+    expect(describeSkippedEntries(selection, 1).join("\n")).toContain("more skipped entry(ies)");
   });
 });
 

--- a/packages/cli/src/harvest.ts
+++ b/packages/cli/src/harvest.ts
@@ -43,10 +43,18 @@ export interface HarvestFile {
 export interface HarvestSelection {
   readonly files: readonly HarvestFile[];
   readonly skipped: Readonly<Partial<Record<HarvestSkipReason, number>>>;
+  /** Why each individual path was left out, in walk order, bounded for reporting. */
+  readonly skippedEntries: readonly {
+    readonly relativePath: string;
+    readonly reason: HarvestSkipReason;
+  }[];
   readonly directoriesVisited: number;
   /** True when the selection cap stopped the walk before every entry was considered. */
   readonly truncated: boolean;
 }
+
+/** How many individual skip reasons one selection keeps for reporting. */
+const MAXIMUM_SKIP_DETAILS = 200;
 
 /** Selection limits; a caller may lower them but never silently exceed them. */
 export interface HarvestOptions {
@@ -134,13 +142,17 @@ export const selectHarvestFiles = async (
 ): Promise<HarvestSelection> => {
   const maximumFiles = options.maximumFiles ?? DEFAULT_MAXIMUM_FILES;
   const skipped: Partial<Record<HarvestSkipReason, number>> = {};
+  const skippedEntries: { relativePath: string; reason: HarvestSkipReason }[] = [];
   const files: HarvestFile[] = [];
   const labels = new Set<string>();
   let directoriesVisited = 0;
   let truncated = false;
 
-  const skip = (reason: HarvestSkipReason): void => {
+  const skip = (reason: HarvestSkipReason, relativePath?: string): void => {
     skipped[reason] = (skipped[reason] ?? 0) + 1;
+    if (relativePath !== undefined && skippedEntries.length < MAXIMUM_SKIP_DETAILS) {
+      skippedEntries.push({ relativePath, reason });
+    }
   };
 
   const walk = async (directory: string): Promise<void> => {
@@ -155,12 +167,12 @@ export const selectHarvestFiles = async (
       if (entry.isSymbolicLink()) {
         // A directory entry for a symlink does not reveal its target, and following it is
         // exactly what this boundary must not do, so every link is reported as one kind.
-        skip("symlink");
+        skip("symlink", relativePath);
         continue;
       }
       if (entry.isDirectory()) {
         if (entry.name.startsWith(".") || IGNORED_DIRECTORIES.has(entry.name)) {
-          skip("dependency-or-build");
+          skip("dependency-or-build", relativePath);
           continue;
         }
         await walk(path);
@@ -169,28 +181,28 @@ export const selectHarvestFiles = async (
       // Credentials are checked first so a dotfile such as `.env` is reported as a
       // credential rather than lumped in with ordinary hidden files.
       if (isCredentialName(entry.name)) {
-        skip("credential");
+        skip("credential", relativePath);
         continue;
       }
       if (entry.name.startsWith(".")) {
-        skip("hidden");
+        skip("hidden", relativePath);
         continue;
       }
       const mediaType = SUPPORTED_EXTENSIONS.get(extname(entry.name).toLowerCase());
       if (mediaType === undefined) {
-        skip("unsupported-format");
+        skip("unsupported-format", relativePath);
         continue;
       }
       const metadata = await lstat(path).catch(() => undefined);
       if (metadata === undefined || !metadata.isFile() || metadata.isSymbolicLink()) {
-        skip("not-a-regular-file");
+        skip("not-a-regular-file", relativePath);
         continue;
       }
       const pathLabel = basename(path);
       if (pathLabel.length === 0 || labels.has(pathLabel)) {
         // The engine records one label per file and rejects duplicates, so a repeated
         // basename is reported rather than silently overwriting another file's evidence.
-        skip("duplicate-name");
+        skip("duplicate-name", relativePath);
         continue;
       }
       if (files.length >= maximumFiles) {
@@ -206,7 +218,26 @@ export const selectHarvestFiles = async (
   // The walk already emits entries in order, but a directory boundary can interleave a
   // deeper path before a sibling file, so the final order is fixed explicitly.
   files.sort((left, right) => compareUtf8(left.relativePath, right.relativePath));
-  return { files, skipped, directoriesVisited, truncated };
+  return { files, skipped, skippedEntries, directoriesVisited, truncated };
+};
+
+/**
+ * Renders the individual files a selection left out, so lost evidence is visible by name.
+ *
+ * @param selection - Result of one directory selection.
+ * @param limit - Largest number of entries to render.
+ * @returns One line per skipped path, plus a count when more were left out.
+ */
+export const describeSkippedEntries = (
+  selection: HarvestSelection,
+  limit = 20,
+): readonly string[] => {
+  const lines = selection.skippedEntries
+    .slice(0, limit)
+    .map((entry) => `  skipped ${entry.relativePath}: ${entry.reason}`);
+  const remaining = selection.skippedEntries.length - lines.length;
+  if (remaining > 0) lines.push(`  ... and ${String(remaining)} more skipped entry(ies).`);
+  return lines;
 };
 
 /**

--- a/packages/cli/src/legacy-import.test.ts
+++ b/packages/cli/src/legacy-import.test.ts
@@ -1,0 +1,122 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { isLegacyPersonDirectory, listLegacyPeople, readLegacyPerson } from "./legacy-import.js";
+
+const roots: string[] = [];
+
+const temporaryRoot = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), "distilly-legacy-"));
+  roots.push(root);
+  return root;
+};
+
+const person = async (
+  parent: string,
+  name: string,
+  files: Readonly<Record<string, string>>,
+): Promise<string> => {
+  const directory = join(parent, name);
+  await mkdir(directory, { recursive: true });
+  for (const [file, content] of Object.entries(files)) {
+    await writeFile(join(directory, file), content);
+  }
+  return directory;
+};
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+describe("legacy person detection", () => {
+  it("recognizes the legacy files and ignores other directories", async () => {
+    const root = await temporaryRoot();
+    const legacy = await person(root, "jiaxiu", {
+      "persona.md": "# Jiaxiu\n",
+      "work.md": "# Work\n",
+    });
+    const other = await person(root, "notes", { "readme.txt": "not a person\n" });
+    expect(await isLegacyPersonDirectory(legacy)).toBe(true);
+    expect(await isLegacyPersonDirectory(other)).toBe(false);
+    expect(await readLegacyPerson(other)).toBeUndefined();
+  });
+
+  it("reads the descriptor name, slug alias, and notes without inventing fields", async () => {
+    const root = await temporaryRoot();
+    const directory = await person(root, "example_jiaxiu", {
+      "persona.md": "# Jiaxiu\n",
+      "meta.json": JSON.stringify({
+        name: "佳秀（示例）",
+        slug: "example_jiaxiu",
+        profile: { role: "HRBP", company: "AI Lab" },
+        impression: "招聘靠谱效率高",
+      }),
+    });
+    const read = await readLegacyPerson(directory);
+    expect(read?.displayName).toBe("佳秀（示例）");
+    expect(read?.aliases).toEqual(["example_jiaxiu"]);
+    expect(read?.described).toBe(true);
+    expect(read?.descriptorNotes.join(" ")).toContain("HRBP at AI Lab");
+    expect(read?.descriptorNotes.join(" ")).toContain("impression");
+  });
+
+  it("falls back to the directory name when the descriptor is missing or broken", async () => {
+    const root = await temporaryRoot();
+    const missing = await person(root, "no-meta", { "persona.md": "# Someone\n" });
+    const missingRead = await readLegacyPerson(missing);
+    expect(missingRead?.displayName).toBe("no-meta");
+    expect(missingRead?.described).toBe(false);
+    expect(missingRead?.aliases).toEqual([]);
+
+    const broken = await person(root, "broken", {
+      "persona.md": "# Someone\n",
+      "meta.json": "{ not json",
+    });
+    const brokenRead = await readLegacyPerson(broken);
+    expect(brokenRead?.displayName).toBe("broken");
+    expect(brokenRead?.described).toBe(false);
+    expect(brokenRead?.descriptorNotes.join(" ")).toContain("meta.json could not be read");
+  });
+
+  it("treats a single person directory as one person and a parent as many", async () => {
+    const root = await temporaryRoot();
+    await person(root, "b-person", { "persona.md": "# B\n" });
+    await person(root, "a-person", {
+      "meta.json": JSON.stringify({ name: "A" }),
+      "work.md": "# A\n",
+    });
+    await person(root, "not-a-person", { "notes.txt": "x\n" });
+    const people = await listLegacyPeople(root);
+    expect(people.map((entry) => entry.displayName)).toEqual(["A", "b-person"]);
+
+    const single = await listLegacyPeople(join(root, "b-person"));
+    expect(single).toHaveLength(1);
+    expect(single[0]?.displayName).toBe("b-person");
+  });
+
+  it("finds people nested under a legacy category directory", async () => {
+    const root = await temporaryRoot();
+    // The real legacy release nests one category level: skills/colleague/<person>.
+    await person(join(root, "skills"), "colleague/example_jiaxiu", {
+      "persona.md": "# Jiaxiu\n",
+      "meta.json": JSON.stringify({ name: "佳秀（示例）", slug: "example_jiaxiu" }),
+    });
+    await person(join(root, "skills"), "celebrity/example_star", { "persona.md": "# Star\n" });
+    const people = await listLegacyPeople(join(root, "skills"));
+    expect(people.map((entry) => entry.displayName)).toEqual(["example_star", "佳秀（示例）"]);
+    const jiaxiu = people.find((entry) => entry.slug === "example_jiaxiu");
+    expect(jiaxiu?.directory.endsWith(join("colleague", "example_jiaxiu"))).toBe(true);
+  });
+
+  it("rejects a path that is not a directory", async () => {
+    const root = await temporaryRoot();
+    const file = join(root, "persona.md");
+    await writeFile(file, "# x\n");
+    await expect(listLegacyPeople(file)).rejects.toThrow(
+      "The import path must be an existing directory.",
+    );
+  });
+});

--- a/packages/cli/src/legacy-import.test.ts
+++ b/packages/cli/src/legacy-import.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -22,7 +22,9 @@ const person = async (
   const directory = join(parent, name);
   await mkdir(directory, { recursive: true });
   for (const [file, content] of Object.entries(files)) {
-    await writeFile(join(directory, file), content);
+    const target = join(directory, file);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, content);
   }
   return directory;
 };
@@ -109,6 +111,26 @@ describe("legacy person detection", () => {
     expect(people.map((entry) => entry.displayName)).toEqual(["example_star", "佳秀（示例）"]);
     const jiaxiu = people.find((entry) => entry.slug === "example_jiaxiu");
     expect(jiaxiu?.directory.endsWith(join("colleague", "example_jiaxiu"))).toBe(true);
+  });
+
+  it("does not treat a category directory with a descriptor as one person", async () => {
+    const root = await temporaryRoot();
+    // A category that happens to carry a meta.json must not swallow the people below it.
+    await person(join(root, "cat"), "colleague", {
+      "meta.json": JSON.stringify({ name: "Colleague Category", slug: "cat" }),
+    });
+    await person(join(root, "cat"), "colleague/alice", {
+      "persona.md": "# Alice\n",
+      "meta.json": JSON.stringify({ name: "Alice", slug: "alice" }),
+    });
+    // A real person directory with a subfolder of notes stays one person.
+    await person(join(root, "cat"), "bob", {
+      "persona.md": "# Bob\n",
+      "notes/extra.md": "# note\n",
+    });
+    const people = await listLegacyPeople(join(root, "cat"));
+    // `bob` has no meta.json, so its directory name is the person name.
+    expect(people.map((entry) => entry.displayName).sort()).toEqual(["Alice", "bob"]);
   });
 
   it("rejects a path that is not a directory", async () => {

--- a/packages/cli/src/legacy-import.ts
+++ b/packages/cli/src/legacy-import.ts
@@ -1,0 +1,166 @@
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * One person directory written by the legacy Skill release.
+ *
+ * The older release kept a person as a folder of Markdown plus a `meta.json` descriptor under
+ * a parent such as `skills/colleague`. Migration has to read that layout without asking the
+ * user to restructure anything, and without guessing when a folder is not a person at all.
+ */
+export interface LegacyPerson {
+  readonly directory: string;
+  /** Directory name, used when the descriptor carries no usable name. */
+  readonly slug: string;
+  readonly displayName: string;
+  readonly aliases: readonly string[];
+  /** True when `meta.json` existed and parsed; false when the folder only had Markdown. */
+  readonly described: boolean;
+  /** Fields the descriptor carried that are not part of the subject itself. */
+  readonly descriptorNotes: readonly string[];
+}
+
+/** How deep the legacy search descends below the given directory. */
+const LEGACY_SEARCH_DEPTH = 4;
+
+/** Files the legacy release always wrote for one person. */
+const LEGACY_PERSON_FILES = ["persona.md", "work.md", "meta.json"] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const asText = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+
+/**
+ * Reports whether one path is a directory that can be read without following a symlink.
+ *
+ * @param path - Candidate path.
+ * @returns True for a real directory.
+ */
+const isDirectory = async (path: string): Promise<boolean> => {
+  try {
+    const metadata = await lstat(path);
+    return metadata.isDirectory() && !metadata.isSymbolicLink();
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Reports whether a directory looks like one legacy person rather than a parent of people.
+ *
+ * @param directory - Candidate directory.
+ * @returns True when the directory carries the legacy person files.
+ */
+export const isLegacyPersonDirectory = async (directory: string): Promise<boolean> => {
+  for (const name of LEGACY_PERSON_FILES) {
+    if (await isDirectory(join(directory, name))) continue;
+    try {
+      const metadata = await lstat(join(directory, name));
+      if (metadata.isFile() && !metadata.isSymbolicLink()) return true;
+    } catch {
+      // Try the next legacy file.
+    }
+  }
+  return false;
+};
+
+/**
+ * Reads one legacy person directory, using `meta.json` for the name and aliases.
+ *
+ * A descriptor that cannot be read or parsed is reported instead of failing the migration: the
+ * Markdown beside it is still the person's evidence, and the directory name is still a name.
+ *
+ * @param directory - Legacy person directory.
+ * @returns The person, or undefined when the directory is not a person directory.
+ */
+export const readLegacyPerson = async (directory: string): Promise<LegacyPerson | undefined> => {
+  if (!(await isLegacyPersonDirectory(directory))) return undefined;
+  const slug = directory.slice(directory.lastIndexOf("/") + 1);
+  let meta: Record<string, unknown> | undefined;
+  let descriptorNotes: string[] = [];
+  try {
+    const parsed: unknown = JSON.parse(await readFile(join(directory, "meta.json"), "utf8"));
+    if (!isRecord(parsed)) throw new Error("meta.json is not an object");
+    meta = parsed;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      meta = undefined;
+    } else {
+      descriptorNotes = [
+        `meta.json could not be read (${error instanceof Error ? error.message : "unknown error"}); the directory name was used instead.`,
+      ];
+    }
+  }
+  const displayName = asText(meta?.["name"]) ?? slug;
+  const aliases: string[] = [];
+  const slugAlias = asText(meta?.["slug"]);
+  if (slugAlias !== undefined && slugAlias !== displayName) aliases.push(slugAlias);
+  if (Array.isArray(meta?.["aliases"])) {
+    for (const alias of meta["aliases"]) {
+      const text = asText(alias);
+      if (text !== undefined && text !== displayName && !aliases.includes(text)) aliases.push(text);
+    }
+  }
+  if (meta !== undefined) {
+    const profile = isRecord(meta["profile"]) ? meta["profile"] : undefined;
+    const role = profile === undefined ? undefined : asText(profile["role"]);
+    const company = profile === undefined ? undefined : asText(profile["company"]);
+    const parts = [role, company].filter((part): part is string => part !== undefined);
+    if (parts.length > 0) {
+      descriptorNotes.push(`The legacy descriptor recorded ${parts.join(" at ")}.`);
+    }
+    if (asText(meta["impression"]) !== undefined) {
+      descriptorNotes.push("The legacy descriptor carried an impression, which stays evidence.");
+    }
+  }
+  return {
+    directory,
+    slug,
+    displayName,
+    aliases,
+    described: meta !== undefined,
+    descriptorNotes,
+  };
+};
+
+/**
+ * Lists the legacy people under one path.
+ *
+ * A path that is itself a person directory is one person; any other path is treated as the
+ * legacy parent directory, and each child directory that looks like a person is one person, in
+ * deterministic name order.
+ *
+ * @param path - Legacy person directory or a parent of them.
+ * @returns Every person found, in a stable order.
+ */
+export const listLegacyPeople = async (path: string): Promise<readonly LegacyPerson[]> => {
+  if (!(await isDirectory(path))) {
+    throw new Error("The import path must be an existing directory.");
+  }
+  const direct = await readLegacyPerson(path);
+  if (direct !== undefined) return [direct];
+  // The legacy release nests one category level between the skills root and each person
+  // (`skills/colleague/<person>`), so the search descends until it finds people rather than
+  // assuming a fixed depth, and never descends into a person directory.
+  const people: LegacyPerson[] = [];
+  const walk = async (directory: string, depth: number): Promise<void> => {
+    if (depth > LEGACY_SEARCH_DEPTH) return;
+    const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries.sort((left, right) =>
+      left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+    )) {
+      if (!entry.isDirectory() || entry.isSymbolicLink() || entry.name.startsWith(".")) continue;
+      const child = join(directory, entry.name);
+      const person = await readLegacyPerson(child);
+      if (person !== undefined) {
+        people.push(person);
+        continue;
+      }
+      await walk(child, depth + 1);
+    }
+  };
+  await walk(path, 1);
+  return people;
+};

--- a/packages/cli/src/legacy-import.ts
+++ b/packages/cli/src/legacy-import.ts
@@ -23,9 +23,6 @@ export interface LegacyPerson {
 /** How deep the legacy search descends below the given directory. */
 const LEGACY_SEARCH_DEPTH = 4;
 
-/** Files the legacy release always wrote for one person. */
-const LEGACY_PERSON_FILES = ["persona.md", "work.md", "meta.json"] as const;
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
@@ -54,16 +51,25 @@ const isDirectory = async (path: string): Promise<boolean> => {
  * @returns True when the directory carries the legacy person files.
  */
 export const isLegacyPersonDirectory = async (directory: string): Promise<boolean> => {
-  for (const name of LEGACY_PERSON_FILES) {
-    if (await isDirectory(join(directory, name))) continue;
+  const hasFile = async (name: string): Promise<boolean> => {
     try {
       const metadata = await lstat(join(directory, name));
-      if (metadata.isFile() && !metadata.isSymbolicLink()) return true;
+      return metadata.isFile() && !metadata.isSymbolicLink();
     } catch {
-      // Try the next legacy file.
+      return false;
     }
+  };
+  // persona.md or work.md are written only for a person, so they settle it immediately.
+  if ((await hasFile("persona.md")) || (await hasFile("work.md"))) return true;
+  if (!(await hasFile("meta.json"))) return false;
+  // A directory that holds only a descriptor but also contains person directories is a
+  // category, not a person: treating it as a person would swallow everyone below it.
+  const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.isSymbolicLink() || entry.name.startsWith(".")) continue;
+    if (await isLegacyPersonDirectory(join(directory, entry.name))) return false;
   }
-  return false;
+  return true;
 };
 
 /**

--- a/packages/cli/src/lifecycle.test.ts
+++ b/packages/cli/src/lifecycle.test.ts
@@ -346,7 +346,11 @@ exit 0
     await executable(join(root, "host-bin", "codex"), "codex-cli 99.0.0");
 
     await expect(setupPreviewHost(BUILTIN_HOSTS.codex, environment)).rejects.toThrow(
-      /verified Distilly briefing capacity/u,
+      /codex-cli 99\.0\.0 has no recorded capacity fixture/u,
+    );
+    // The message must name the way forward, or a host update is a dead end.
+    await expect(setupPreviewHost(BUILTIN_HOSTS.codex, environment)).rejects.toThrow(
+      /--allow-unverified-host/u,
     );
     await expect(readFile(join(home, ".distilly", "install.json"))).rejects.toMatchObject({
       code: "ENOENT",

--- a/packages/cli/src/lifecycle.ts
+++ b/packages/cli/src/lifecycle.ts
@@ -119,6 +119,13 @@ interface LifecyclePaths {
 /** Trusted local paths used by the repo-local Developer Preview lifecycle. */
 export interface PreviewLifecycleEnvironment {
   readonly homeDirectory: string;
+  /**
+   * DSH's own home directory when the selected host is DSH.
+   *
+   * DSH boots profiles from `$DSH_HOME` (default `~/.dsh`), which is not the ordinary user
+   * home, so the binding must be rooted there or the installed profile is never read.
+   */
+  readonly dshHomeDirectory?: string;
   readonly nodePath: string;
   readonly entryPath: string;
   readonly pluginSourcesPath: string;
@@ -681,7 +688,10 @@ const createBinding = (
   allowUnverifiedHost = false,
 ): HostBinding => {
   const options = {
-    homeDirectory: environment.homeDirectory,
+    homeDirectory:
+      host === BUILTIN_HOSTS.dsh
+        ? (environment.dshHomeDirectory ?? environment.homeDirectory)
+        : environment.homeDirectory,
     forms,
     provider: {
       load: (context: { readonly environment: "desktop" | "cli" | "ci" }) => {
@@ -729,6 +739,7 @@ const createBinding = (
 
 const pluginSource = (pluginSourcesPath: string, host: HostName): string => {
   if (host === BUILTIN_HOSTS.codex) return join(pluginSourcesPath, "codex");
+  if (host === BUILTIN_HOSTS.dsh) return join(pluginSourcesPath, "dsh");
   if (host === BUILTIN_HOSTS.hermes) return join(pluginSourcesPath, "shared", "skills", "distilly");
   return join(pluginSourcesPath, "claude-code");
 };

--- a/packages/cli/src/lifecycle.ts
+++ b/packages/cli/src/lifecycle.ts
@@ -871,7 +871,16 @@ export const setupPreviewHost = async (
     options.allowUnverifiedHost === true,
   );
   const preflight = await binding.preflight({ sessionId: `setup-${host}`, environment: "cli" });
-  if (!preflight.ok) throw fail(preflight.error.message);
+  if (!preflight.ok) {
+    // A host version with no recorded fixture is the common case after a host update. Say what
+    // was measured for what, and name the flag that installs anyway, instead of dead-ending.
+    if (preflight.error.code === "host_unsupported") {
+      throw fail(
+        `${preflight.error.message} ${host} ${hostVersion} has no recorded capacity fixture in this release. Install a host version that has one, or re-run this command with --allow-unverified-host to install on the conservative floor (doctor keeps reporting it).`,
+      );
+    }
+    throw fail(preflight.error.message);
+  }
   const unverifiedHost =
     preflight.evidence.kind === "unverified_host_version" ? (true as const) : undefined;
   await ensureRoot(paths.root);

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -11,6 +11,7 @@ const environment: PreviewCliEnvironment = {
     pathValue: "",
   },
   panelAssetsPath: "/tmp/distilly-preview-panel",
+  dshHomeDirectory: "/tmp/distilly-preview-home/.dsh",
 };
 
 describe("Developer Preview CLI host boundary", () => {

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -200,6 +200,67 @@ describe("Developer Preview CLI host boundary", () => {
     expect(stdout).toEqual([]);
   });
 
+  it("requires a legacy directory and a host for import", async () => {
+    const stdout: string[] = [];
+    const io = {
+      stdout: { write: (value: string) => stdout.push(value) },
+      stderr: { write: (value: string) => value },
+    };
+    await expect(runPreviewCli(["import", "--host", "codex"], environment, io)).rejects.toThrow(
+      "This command requires a legacy person or skills directory, then --host <host>.",
+    );
+    await expect(runPreviewCli(["import", "/tmp/legacy-skills"], environment, io)).rejects.toThrow(
+      "This command requires --host.",
+    );
+    await expect(
+      runPreviewCli(
+        ["import", "/tmp/legacy-skills", "--host", "codex", "--nope", "1"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("Unknown import option: --nope.");
+    await expect(
+      runPreviewCli(
+        ["import", "/tmp/legacy-skills", "--host", "codex", "--sensitivity", "public"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("--sensitivity must be private or shareable.");
+    await expect(
+      runPreviewCli(
+        ["import", "/tmp/legacy-skills", "--host", "codex", "--limit", "0"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("--limit must be positive.");
+    expect(stdout).toEqual([]);
+  });
+
+  it("rejects an import path that does not exist before opening the host", async () => {
+    const io = {
+      stdout: { write: (value: string) => value },
+      stderr: { write: (value: string) => value },
+    };
+    await expect(
+      runPreviewCli(
+        ["import", "/tmp/distilly-missing-legacy-dir", "--host", "codex"],
+        environment,
+        io,
+      ),
+    ).rejects.toThrow("The import path must be an existing directory.");
+  });
+
+  it("documents the legacy import command", async () => {
+    const stdout: string[] = [];
+    await expect(
+      runPreviewCli(["--help"], environment, {
+        stdout: { write: (value: string) => stdout.push(value) },
+        stderr: { write: (value: string) => value },
+      }),
+    ).resolves.toBe(0);
+    expect(stdout.join("")).toContain("distilly import <legacy-directory> --host <host>");
+  });
+
   it("documents the version commands", async () => {
     const stdout: string[] = [];
     await expect(

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -62,6 +62,13 @@ export interface PreviewCliIo {
 export interface PreviewCliEnvironment {
   readonly lifecycle: PreviewLifecycleEnvironment;
   readonly panelAssetsPath: string;
+  /**
+   * DSH's own home directory.
+   *
+   * DSH reads `$DSH_HOME`, or `~/.dsh` when that variable is unset, so its profile tree and
+   * skills root do not live under the ordinary user home and must not be guessed from it.
+   */
+  readonly dshHomeDirectory: string;
 }
 
 const parseHost = (value: string | undefined): HostName => {
@@ -82,6 +89,19 @@ const hostOption = (args: readonly string[], required: boolean): HostName | unde
   }
   return parseHost(args[1]);
 };
+
+/**
+ * Names the home directory one command must target for a host.
+ *
+ * DSH keeps its profile tree and skills root under `$DSH_HOME` (default `~/.dsh`), not under
+ * the ordinary user home, so the two are resolved separately.
+ *
+ * @param host - Selected host.
+ * @param environment - Resolved Preview CLI environment.
+ * @returns Absolute host home directory.
+ */
+const hostHome = (host: HostName, environment: PreviewCliEnvironment): string =>
+  host === BUILTIN_HOSTS.dsh ? environment.dshHomeDirectory : environment.lifecycle.homeDirectory;
 
 const openApplication = async (host: HostName, environment: PreviewCliEnvironment) => {
   const binding = await requireInstalledPreviewBinding(environment.lifecycle, host);
@@ -169,9 +189,15 @@ export const resolvePreviewCliEnvironment = async (): Promise<PreviewCliEnvironm
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
       throw error;
     });
+  const dshHomeDirectory = resolve(
+    process.env["DSH_HOME"] !== undefined && process.env["DSH_HOME"].trim().length > 0
+      ? process.env["DSH_HOME"]
+      : join(configuredHome, ".dsh"),
+  );
   return {
     lifecycle: {
       homeDirectory: resolve(configuredHome),
+      dshHomeDirectory,
       nodePath: await realpath(process.execPath),
       entryPath,
       pluginSourcesPath: await realpath(
@@ -185,6 +211,7 @@ export const resolvePreviewCliEnvironment = async (): Promise<PreviewCliEnvironm
     panelAssetsPath: await realpath(
       packaged ? join(runtimeRoot, PREVIEW_PANEL_ASSETS) : resolve(packageRoot, "../panel/web"),
     ),
+    dshHomeDirectory,
   };
 };
 
@@ -454,7 +481,13 @@ const runHarvest = async (
       }
     };
     const recordResult = (
-      result: { subject: { id: string; displayName: string } },
+      result: {
+        readonly subject: { readonly id: string; readonly displayName: string };
+        readonly items: readonly {
+          readonly pathLabel: string;
+          readonly warnings: readonly string[];
+        }[];
+      },
       count: number,
       batch: readonly (typeof files)[number][],
     ) => {
@@ -464,6 +497,13 @@ const runHarvest = async (
       io.stdout.write(
         `Ingested ${String(ingested)}/${String(files.length)} new file(s) as ${result.subject.displayName} (${result.subject.id}).\n`,
       );
+      // A file can be stored and still not be usable as evidence: the parser may have skipped
+      // parts, refused to split it, or found no text. Those observations must reach the user,
+      // or a harvest looks complete while the material is not what they expect.
+      for (const item of result.items) {
+        if (item.warnings.length === 0) continue;
+        io.stdout.write(`  ${item.pathLabel}: ${item.warnings.join(" ")}\n`);
+      }
     };
     for (const batch of batches) {
       try {
@@ -709,7 +749,7 @@ const runPersonas = async (
     index += 1;
   }
   if (host === undefined) throw new Error("This command requires --host.");
-  const summaries = await listPersonInstalls(host, environment.lifecycle.homeDirectory);
+  const summaries = await listPersonInstalls(host, hostHome(host, environment));
   if (asJson) {
     io.stdout.write(`${JSON.stringify({ host, installs: summaries }, undefined, 2)}\n`);
     return;
@@ -757,7 +797,7 @@ const runRemove = async (
   const application = await openApplication(host, environment);
   try {
     const subject = await resolveSubjectArgument(application.distilly, subjectArgument, io);
-    const summaries = await listPersonInstalls(host, environment.lifecycle.homeDirectory);
+    const summaries = await listPersonInstalls(host, hostHome(host, environment));
     const install = summaries.find(
       (summary): summary is Extract<PersonInstallSummary, { verified: true }> =>
         summary.verified && summary.install.subjectId === subject.id,

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -25,6 +25,7 @@ import {
 } from "./lifecycle.js";
 import {
   describeHarvestSelection,
+  describeSkippedEntries,
   recordBudgetExceeded,
   selectHarvestFiles,
   type HarvestFile,
@@ -341,6 +342,10 @@ interface IngestRequest {
   readonly sensitivity?: "private" | "shareable";
   readonly force: boolean;
   readonly maximumFiles?: number;
+  /** Suppresses progress lines so a caller can emit machine-readable output instead. */
+  readonly quiet?: boolean;
+  /** What the caller is importing from, used when an existing subject absorbs the material. */
+  readonly sourceLabel?: string;
 }
 
 /** What one ingest request stored, so a caller importing several people can report per person. */
@@ -363,9 +368,29 @@ const ingestFileSelection = async (
   environment: PreviewCliEnvironment,
   io: PreviewCliIo,
 ): Promise<IngestOutcome> => {
+  const say = (line: string): void => {
+    if (request.quiet !== true) io.stdout.write(line);
+  };
   const application = await openApplication(request.host, environment);
   try {
+    const statePath = join(environment.lifecycle.homeDirectory, ".distilly", "harvest-state.json");
+    const state = await loadHarvestState(statePath);
     let subjectId: string | undefined = request.subjectId;
+    // The record stores real paths, so the comparison must use the source's real path too.
+    const sourcePrefix =
+      request.sourceLabel === undefined ? undefined : `${await recordedPath(request.sourceLabel)}/`;
+    /**
+     * Reports whether this subject already recorded a file from the directory being imported.
+     *
+     * Re-importing the same directory is routine and needs no explanation; a second directory
+     * with the same person name is the case worth telling the operator about.
+     *
+     * @returns True when the record links this subject to the importing directory.
+     */
+    const knownSource = (): boolean =>
+      sourcePrefix !== undefined &&
+      subjectId !== undefined &&
+      (state.entries[subjectId] ?? []).some((entry) => entry.path.startsWith(sourcePrefix));
     if (subjectId === undefined) {
       // Resolve the name before creating anything. The engine answers with the one subject it
       // matched, several candidates, or none, and the CLI acts on that answer instead of
@@ -375,15 +400,22 @@ const ingestFileSelection = async (
       });
       if (resolution.kind === "found") {
         subjectId = resolution.subject.id;
-        io.stdout.write(
+        say(
           `${resolution.subject.displayName} (${resolution.subject.id}) already exists in ${resolution.subject.space.displayName}, so this material is added to it.\n`,
         );
+        if (request.command === "import" && request.sourceLabel !== undefined && !knownSource()) {
+          // An exact name match is the same person to the engine, but a legacy tree can hold two
+          // directories with one name, so name the directory that was absorbed.
+          say(
+            `  Note: ${request.sourceLabel} was merged into that subject because the name matches exactly. Pass --name "<a different name>" to import it as a separate person.\n`,
+          );
+        }
       } else if (resolution.kind === "ambiguous") {
         for (const line of describeAmbiguousSubject(
           request.displayName ?? "",
           resolution.candidates,
         )) {
-          io.stdout.write(`${line}\n`);
+          say(`${line}\n`);
         }
         throw new Error(
           `More than one subject matches that name. Repeat ${request.command} with --subject <subject-id>.`,
@@ -410,14 +442,12 @@ const ingestFileSelection = async (
           if (cursor === undefined) break;
         }
         if (nearDuplicate !== undefined) {
-          io.stdout.write(
+          say(
             `Note: ${nearDuplicate.displayName} (${nearDuplicate.id}) already exists in ${nearDuplicate.space.displayName} with different capitalization; a new subject is created. Pass --subject ${nearDuplicate.id} to add to that one instead.\n`,
           );
         }
       }
     }
-    const statePath = join(environment.lifecycle.homeDirectory, ".distilly", "harvest-state.json");
-    const state = await loadHarvestState(statePath);
     const failures: string[] = [];
     const hashed: HashedHarvestFile[] = [];
     for (const file of request.files) {
@@ -430,7 +460,7 @@ const ingestFileSelection = async (
       } catch (error) {
         const reason = error instanceof Error ? error.message : "the file could not be read";
         failures.push(`${file.pathLabel}: ${reason}`);
-        io.stdout.write(`Could not read ${file.pathLabel}: ${reason}\n`);
+        say(`Could not read ${file.pathLabel}: ${reason}\n`);
       }
     }
     let files = hashed;
@@ -439,32 +469,36 @@ const ingestFileSelection = async (
       const plan = planHarvest(files, recorded);
       if (plan.alreadyIngested.length > 0) {
         for (const file of plan.alreadyIngested) {
-          io.stdout.write(
+          say(
             `Skipped ${file.pathLabel}: already ingested for this subject; pass --force to ingest it again.\n`,
           );
         }
       }
       files = [...plan.ingest];
     } else if (request.force && files.length > 0) {
-      io.stdout.write(
+      say(
         `--force re-ingests ${String(files.length)} file(s) even if they are unchanged, so the store gains a new material record for each one.\n`,
       );
     }
     if (request.maximumFiles !== undefined && files.length > request.maximumFiles) {
       const remaining = files.length - request.maximumFiles;
       files = files.slice(0, request.maximumFiles);
-      io.stdout.write(
+      say(
         `Reached --limit ${String(request.maximumFiles)}; ${String(remaining)} more file(s) still need ingesting. Re-run to continue.\n`,
       );
     }
     if (files.length === 0) {
-      io.stdout.write("Nothing new to ingest.\n");
+      say("Nothing new to ingest.\n");
       if (failures.length > 0) {
         throw new Error(
           `${String(failures.length)} of ${String(request.files.length)} file(s) could not be ingested:\n${failures.join("\n")}`,
         );
       }
-      return { ingested: 0, failures };
+      return {
+        ...(subjectId === undefined ? {} : { subjectId }),
+        ingested: 0,
+        failures,
+      };
     }
     // A file larger than one material is split by the runtime into parts, so it must travel
     // alone: a batch of several oversized files could exceed the wire limit for one result.
@@ -524,8 +558,25 @@ const ingestFileSelection = async (
         // subject keeps the one-shot flow working instead of failing on a duplicate.
         const reuse = reusableSubject(error);
         if (reuse !== undefined) {
+          // A conflict is only "the same person" when the engine matched the display name we
+          // asked for. A match through an alias can be a different person who happens to own
+          // that alias, and merging two people silently is worse than refusing.
+          const wanted = request.displayName ?? "";
+          if (wanted.length > 0 && reuse.displayName !== wanted) {
+            const collided = (request.aliases ?? []).filter((alias) =>
+              reuse.aliases.includes(alias),
+            );
+            const because =
+              collided.length === 0
+                ? `The name "${wanted}" collides with alias or identity records of a different subject`
+                : `The legacy alias ${collided.map((alias) => `"${alias}"`).join(", ")} already belongs to a subject named`;
+            throw new Error(
+              `${because} ${reuse.displayName} (${reuse.id}). Nothing was stored. Pass --subject ${reuse.id} if that subject really is the same person, or import a copy whose meta.json uses a different slug.`,
+              { cause: error },
+            );
+          }
           subjectId = reuse.id;
-          io.stdout.write(
+          say(
             `${reuse.displayName} (${reuse.id}) already exists, so this material was added to it.\n`,
           );
           return await ingest({ kind: "existing", subjectId: reuse.id }, batch);
@@ -533,7 +584,7 @@ const ingestFileSelection = async (
         const candidates = ambiguousCandidates(error);
         if (candidates === undefined) throw error;
         for (const line of describeAmbiguousSubject(request.displayName ?? "", candidates)) {
-          io.stdout.write(`${line}\n`);
+          say(`${line}\n`);
         }
         throw new Error(
           `More than one subject matches that name. Repeat ${request.command} with --subject <subject-id>.`,
@@ -563,7 +614,7 @@ const ingestFileSelection = async (
       subjectId = result.subject.id;
       ingested += count;
       recordedState = recordHarvest(recordedState, result.subject.id, batch);
-      io.stdout.write(
+      say(
         `Ingested ${String(ingested)}/${String(files.length)} new file(s) as ${result.subject.displayName} (${result.subject.id}).\n`,
       );
       // A file can be stored and still not be usable as evidence: the parser may have skipped
@@ -571,7 +622,7 @@ const ingestFileSelection = async (
       // or a harvest looks complete while the material is not what they expect.
       for (const item of result.items) {
         if (item.warnings.length === 0) continue;
-        io.stdout.write(`  ${item.pathLabel}: ${item.warnings.join(" ")}\n`);
+        say(`  ${item.pathLabel}: ${item.warnings.join(" ")}\n`);
       }
     };
     for (const batch of batches) {
@@ -581,7 +632,7 @@ const ingestFileSelection = async (
         // A batch can exceed the record budget because one file splits into several records.
         // Retry that batch one file per call so one expanding file cannot lose the others.
         if (!recordBudgetExceeded(error) || batch.length === 1) throw error;
-        io.stdout.write(
+        say(
           "That batch expands past one call's record budget; ingesting its files one at a time.\n",
         );
         for (const file of batch) {
@@ -590,7 +641,7 @@ const ingestFileSelection = async (
           } catch (fileError) {
             const reason = fileError instanceof Error ? fileError.message : "unknown failure";
             failures.push(`${file.pathLabel}: ${reason}`);
-            io.stdout.write(`Skipped ${file.pathLabel}: ${reason}\n`);
+            say(`Skipped ${file.pathLabel}: ${reason}\n`);
           }
         }
       }
@@ -1195,7 +1246,14 @@ const runImport = async (
     );
   }
   const single = people.length === 1 ? people[0] : undefined;
-  const displayName = options.displayName ?? single?.displayName;
+  const declaredName = options.displayName;
+  // --json must stay machine-readable, so every human line is collected and either printed
+  // before the JSON (never interleaved with it) or dropped.
+  const log: string[] = [];
+  const note = (line: string): void => {
+    if (!options.asJson) io.stdout.write(`${line}\n`);
+    log.push(line);
+  };
   const outcomes: {
     readonly directory: string;
     readonly displayName: string;
@@ -1204,24 +1262,31 @@ const runImport = async (
   }[] = [];
   const failures: string[] = [];
   for (const person of people) {
-    io.stdout.write(`\n${person.displayName} (${person.directory})\n`);
-    for (const note of person.descriptorNotes) io.stdout.write(`  ${note}\n`);
+    note(`\n${person.displayName} (${person.directory})`);
+    for (const descriptorNote of person.descriptorNotes) note(`  ${descriptorNote}`);
     if (!person.described) {
-      io.stdout.write("  No meta.json was read; the directory name was used as the name.\n");
-    }
-    const selection = await selectHarvestFiles(person.directory);
-    for (const line of describeHarvestSelection(selection)) io.stdout.write(`  ${line}\n`);
-    if (selection.files.length === 0) {
-      io.stdout.write("  No supported evidence file was found; this person was skipped.\n");
-      failures.push(`${person.displayName}: no supported evidence file`);
-      continue;
+      note("  No meta.json was read; the directory name was used as the name.");
     }
     const isSingle = single !== undefined;
     // Every person keeps its own name; only a single-directory import can override it, and only
     // a single-directory import may target an existing subject.
-    const personName = isSingle && displayName !== undefined ? displayName : person.displayName;
+    const personName = isSingle && declaredName !== undefined ? declaredName : person.displayName;
     const personSubjectId = isSingle ? options.subjectId : undefined;
-    const personAliases = options.displayName === undefined ? person.aliases : [];
+    const personAliases = person.aliases;
+    if (Buffer.byteLength(personName, "utf8") > WIRE_LIMITS.labelBytes) {
+      const reason = `the name is ${String(Buffer.byteLength(personName, "utf8"))} bytes, longer than the ${String(WIRE_LIMITS.labelBytes)}-byte subject label limit; pass --name with a shorter name`;
+      failures.push(`${person.displayName}: ${reason}`);
+      note(`  Could not import ${person.displayName}: ${reason}`);
+      continue;
+    }
+    const selection = await selectHarvestFiles(person.directory);
+    note(`  ${describeHarvestSelection(selection).join("\n  ")}`);
+    for (const line of describeSkippedEntries(selection)) note(line);
+    if (selection.files.length === 0) {
+      note("  No supported evidence file was found; this person was skipped.");
+      failures.push(`${person.displayName}: no supported evidence file`);
+      continue;
+    }
     try {
       const outcome = await ingestFileSelection(
         {
@@ -1229,6 +1294,8 @@ const runImport = async (
           host: options.host,
           files: selection.files,
           force: options.force,
+          quiet: options.asJson,
+          sourceLabel: person.directory,
           ...(personSubjectId === undefined
             ? { displayName: personName }
             : { subjectId: personSubjectId }),
@@ -1248,24 +1315,25 @@ const runImport = async (
     } catch (error) {
       const reason = error instanceof Error ? error.message : "unknown failure";
       failures.push(`${person.displayName}: ${reason}`);
-      io.stdout.write(`  Could not import ${person.displayName}: ${reason}\n`);
+      note(`  Could not import ${person.displayName}: ${reason}`);
     }
   }
   if (options.asJson) {
-    io.stdout.write(`${JSON.stringify({ people: outcomes, failures }, undefined, 2)}\n`);
-  } else {
+    io.stdout.write(`${JSON.stringify({ people: outcomes, failures, log }, undefined, 2)}\n`);
+    if (failures.length > 0) process.exitCode = 1;
+    return;
+  }
+  io.stdout.write(
+    `\nImported ${String(outcomes.length)} of ${String(people.length)} legacy person(s).\n`,
+  );
+  for (const outcome of outcomes) {
     io.stdout.write(
-      `\nImported ${String(outcomes.length)} of ${String(people.length)} legacy person(s).\n`,
-    );
-    for (const outcome of outcomes) {
-      io.stdout.write(
-        `  ${outcome.displayName} -> ${outcome.subjectId ?? "(unchanged target)"} (${String(outcome.ingested)} file(s))\n`,
-      );
-    }
-    io.stdout.write(
-      "Next: ask the host that has Distilly installed to distill these people, then review the profiles with distilly show.\n",
+      `  ${outcome.displayName} -> ${outcome.subjectId ?? "(no subject was resolved)"} (${String(outcome.ingested)} file(s))\n`,
     );
   }
+  io.stdout.write(
+    "Next: ask the host that has Distilly installed to distill these people, then review the profiles with distilly show.\n",
+  );
   if (failures.length > 0) {
     throw new Error(
       `${String(failures.length)} of ${String(people.length)} legacy person(s) could not be imported:\n${failures.join("\n")}`,

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -23,7 +23,12 @@ import {
   uninstallPreviewHost,
   type PreviewLifecycleEnvironment,
 } from "./lifecycle.js";
-import { describeHarvestSelection, recordBudgetExceeded, selectHarvestFiles } from "./harvest.js";
+import {
+  describeHarvestSelection,
+  recordBudgetExceeded,
+  selectHarvestFiles,
+  type HarvestFile,
+} from "./harvest.js";
 import {
   hashFile,
   loadHarvestState,
@@ -40,6 +45,7 @@ import {
   describeSubjectList,
   looksLikeSubjectId,
 } from "./show.js";
+import { listLegacyPeople } from "./legacy-import.js";
 import {
   describeProfileDiff,
   describeVersions,
@@ -300,15 +306,72 @@ const runHarvest = async (
     io.stdout.write("Nothing to ingest.\n");
     return;
   }
-  const application = await openApplication(options.host, environment);
+  await ingestFileSelection(
+    {
+      command: "harvest",
+      host: options.host,
+      files: selection.files,
+      force: options.force,
+      ...(options.displayName === undefined ? {} : { displayName: options.displayName }),
+      ...(options.subjectId === undefined ? {} : { subjectId: options.subjectId }),
+      ...(options.sensitivity === undefined ? {} : { sensitivity: options.sensitivity }),
+      ...(options.maximumFiles === undefined ? {} : { maximumFiles: options.maximumFiles }),
+    },
+    environment,
+    io,
+  );
+};
+
+/**
+ * One selected batch of local files plus how it should reach a subject.
+ *
+ * Harvest and import share this request so both keep the same subject resolution, the same
+ * already-ingested record, the same wire batching, and the same per-file failure reporting.
+ */
+interface IngestRequest {
+  /** Command name used in operator-facing messages. */
+  readonly command: string;
+  readonly host: HostName;
+  readonly files: readonly HarvestFile[];
+  /** Create-or-reuse target: set exactly one, or neither to let the engine create one. */
+  readonly displayName?: string;
+  readonly subjectId?: string;
+  /** Aliases used only when this request creates the subject. */
+  readonly aliases?: readonly string[];
+  readonly sensitivity?: "private" | "shareable";
+  readonly force: boolean;
+  readonly maximumFiles?: number;
+}
+
+/** What one ingest request stored, so a caller importing several people can report per person. */
+interface IngestOutcome {
+  readonly subjectId?: string;
+  readonly ingested: number;
+  readonly failures: readonly string[];
+}
+
+/**
+ * Ingests one selected batch of local files into a resolved, reused, or new subject.
+ *
+ * @param request - Selected files plus the subject target and limits.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ * @returns The subject that received the material and what failed.
+ */
+const ingestFileSelection = async (
+  request: IngestRequest,
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<IngestOutcome> => {
+  const application = await openApplication(request.host, environment);
   try {
-    let subjectId: string | undefined = options.subjectId;
+    let subjectId: string | undefined = request.subjectId;
     if (subjectId === undefined) {
       // Resolve the name before creating anything. The engine answers with the one subject it
       // matched, several candidates, or none, and the CLI acts on that answer instead of
       // discovering a conflict after a create attempt.
       const resolution = await application.distilly.resolve({
-        selector: { kind: "query", query: options.displayName ?? "" },
+        selector: { kind: "query", query: request.displayName ?? "" },
       });
       if (resolution.kind === "found") {
         subjectId = resolution.subject.id;
@@ -317,26 +380,26 @@ const runHarvest = async (
         );
       } else if (resolution.kind === "ambiguous") {
         for (const line of describeAmbiguousSubject(
-          options.displayName ?? "",
+          request.displayName ?? "",
           resolution.candidates,
         )) {
           io.stdout.write(`${line}\n`);
         }
         throw new Error(
-          "More than one subject matches that name. Repeat harvest with --subject <subject-id>.",
+          `More than one subject matches that name. Repeat ${request.command} with --subject <subject-id>.`,
         );
       } else {
         // The engine treats differently capitalized names as different people, so a new
         // subject is correct here; say so when a near-duplicate exists instead of silently
         // splitting one person's material across two subjects.
-        const wanted = (options.displayName ?? "").toLowerCase();
+        const wanted = (request.displayName ?? "").toLowerCase();
         let nearDuplicate: SubjectSummary | undefined;
         let cursor: string | undefined;
         // Page through the whole filtered listing: the case-variant may sort past any fixed
         // window, and a missed warning silently splits one person across two subjects.
         for (let page = 0; page < 20 && nearDuplicate === undefined; page += 1) {
           const listed = await application.distilly.list({
-            text: options.displayName ?? "",
+            text: request.displayName ?? "",
             limit: 200,
             ...(cursor === undefined ? {} : { cursor }),
           });
@@ -357,7 +420,7 @@ const runHarvest = async (
     const state = await loadHarvestState(statePath);
     const failures: string[] = [];
     const hashed: HashedHarvestFile[] = [];
-    for (const file of selection.files) {
+    for (const file of request.files) {
       try {
         hashed.push({
           ...file,
@@ -372,7 +435,7 @@ const runHarvest = async (
     }
     let files = hashed;
     const recorded = subjectId === undefined ? [] : (state.entries[subjectId] ?? []);
-    if (!options.force && recorded.length > 0) {
+    if (!request.force && recorded.length > 0) {
       const plan = planHarvest(files, recorded);
       if (plan.alreadyIngested.length > 0) {
         for (const file of plan.alreadyIngested) {
@@ -382,26 +445,26 @@ const runHarvest = async (
         }
       }
       files = [...plan.ingest];
-    } else if (options.force && files.length > 0) {
+    } else if (request.force && files.length > 0) {
       io.stdout.write(
         `--force re-ingests ${String(files.length)} file(s) even if they are unchanged, so the store gains a new material record for each one.\n`,
       );
     }
-    if (options.maximumFiles !== undefined && files.length > options.maximumFiles) {
-      const remaining = files.length - options.maximumFiles;
-      files = files.slice(0, options.maximumFiles);
+    if (request.maximumFiles !== undefined && files.length > request.maximumFiles) {
+      const remaining = files.length - request.maximumFiles;
+      files = files.slice(0, request.maximumFiles);
       io.stdout.write(
-        `Reached --limit ${String(options.maximumFiles)}; ${String(remaining)} more file(s) still need ingesting. Re-run to continue.\n`,
+        `Reached --limit ${String(request.maximumFiles)}; ${String(remaining)} more file(s) still need ingesting. Re-run to continue.\n`,
       );
     }
     if (files.length === 0) {
       io.stdout.write("Nothing new to ingest.\n");
       if (failures.length > 0) {
         throw new Error(
-          `${String(failures.length)} of ${String(selection.files.length)} file(s) could not be ingested:\n${failures.join("\n")}`,
+          `${String(failures.length)} of ${String(request.files.length)} file(s) could not be ingested:\n${failures.join("\n")}`,
         );
       }
-      return;
+      return { ingested: 0, failures };
     }
     // A file larger than one material is split by the runtime into parts, so it must travel
     // alone: a batch of several oversized files could exceed the wire limit for one result.
@@ -440,11 +503,17 @@ const runHarvest = async (
             : { kind: "existing", subjectId: subjectIdSchema.parse(target.subjectId) },
         paths: batch.map((file) => file.path),
         enqueue: "now",
-        ...(options.sensitivity === undefined ? {} : { sensitivity: options.sensitivity }),
+        ...(request.sensitivity === undefined ? {} : { sensitivity: request.sensitivity }),
       });
     const ingestTarget = () =>
       subjectId === undefined
-        ? ({ kind: "create", input: { displayName: options.displayName ?? "" } } as const)
+        ? ({
+            kind: "create",
+            input: {
+              displayName: request.displayName ?? "",
+              ...(request.aliases === undefined ? {} : { aliases: [...request.aliases] }),
+            },
+          } as const)
         : ({ kind: "existing", subjectId } as const);
     const ingestWithSubjectReuse = async (batch: readonly (typeof files)[number][]) => {
       try {
@@ -463,11 +532,11 @@ const runHarvest = async (
         }
         const candidates = ambiguousCandidates(error);
         if (candidates === undefined) throw error;
-        for (const line of describeAmbiguousSubject(options.displayName ?? "", candidates)) {
+        for (const line of describeAmbiguousSubject(request.displayName ?? "", candidates)) {
           io.stdout.write(`${line}\n`);
         }
         throw new Error(
-          "More than one subject matches that name. Repeat harvest with --subject <subject-id>.",
+          `More than one subject matches that name. Repeat ${request.command} with --subject <subject-id>.`,
           { cause: error },
         );
       }
@@ -532,6 +601,11 @@ const runHarvest = async (
         `${String(failures.length)} of ${String(files.length)} file(s) could not be ingested:\n${failures.join("\n")}`,
       );
     }
+    return {
+      ...(subjectId === undefined ? {} : { subjectId }),
+      ingested,
+      failures,
+    };
   } finally {
     await application.close();
   }
@@ -1025,6 +1099,180 @@ const runRollback = async (
   }
 };
 
+/**
+ * Reads one path plus host, subject, and limit options for the legacy import command.
+ *
+ * @param args - Legacy directory plus options.
+ * @returns Parsed options.
+ */
+const importOptions = (
+  args: readonly string[],
+): {
+  readonly directory: string;
+  readonly host: HostName;
+  readonly displayName?: string;
+  readonly subjectId?: string;
+  readonly sensitivity?: "private" | "shareable";
+  readonly maximumFiles?: number;
+  readonly force: boolean;
+  readonly asJson: boolean;
+} => {
+  const [directory, ...rest] = args;
+  if (directory === undefined || directory.startsWith("--")) {
+    throw new Error(
+      "This command requires a legacy person or skills directory, then --host <host>.",
+    );
+  }
+  let host: HostName | undefined;
+  let asJson = false;
+  const parsed: {
+    displayName?: string;
+    subjectId?: string;
+    sensitivity?: "private" | "shareable";
+    maximumFiles?: number;
+    force?: boolean;
+  } = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const flag = rest[index];
+    if (flag === "--force") {
+      parsed.force = true;
+      continue;
+    }
+    if (flag === "--json") {
+      asJson = true;
+      continue;
+    }
+    const value = rest[index + 1];
+    if (value === undefined) throw new Error(`Missing value for ${String(flag)}.`);
+    if (flag === "--host") host = parseHost(value);
+    else if (flag === "--name") parsed.displayName = value;
+    else if (flag === "--subject") parsed.subjectId = value;
+    else if (flag === "--sensitivity") {
+      if (value !== "private" && value !== "shareable") {
+        throw new Error("--sensitivity must be private or shareable.");
+      }
+      parsed.sensitivity = value;
+    } else if (flag === "--limit") {
+      const limit = Number.parseInt(value, 10);
+      if (!Number.isSafeInteger(limit) || limit <= 0) throw new Error("--limit must be positive.");
+      parsed.maximumFiles = limit;
+    } else {
+      throw new Error(`Unknown import option: ${String(flag)}.`);
+    }
+    index += 1;
+  }
+  if (host === undefined) throw new Error("This command requires --host.");
+  return { directory, host, force: parsed.force === true, asJson, ...parsed };
+};
+
+/**
+ * Imports people written by the legacy Skill release as Distilly material.
+ *
+ * The legacy release kept each person as a folder of Markdown beside a `meta.json` descriptor.
+ * Migration reads that layout as it is, creates or reuses one subject per person, and ingests
+ * every supported file as evidence, so the host can distill a V3 profile from the same material
+ * the old Skill used. Nothing is deleted and the legacy directory is never modified.
+ *
+ * @param args - Legacy directory plus host and subject options.
+ * @param environment - Resolved Preview CLI environment.
+ * @param io - Command output streams.
+ */
+const runImport = async (
+  args: readonly string[],
+  environment: PreviewCliEnvironment,
+  io: PreviewCliIo,
+): Promise<void> => {
+  const options = importOptions(args);
+  const people = await listLegacyPeople(options.directory);
+  if (people.length === 0) {
+    throw new Error(
+      `No legacy person directory was found under ${options.directory}. Expected a folder with persona.md, work.md, or meta.json, or a parent folder of such folders.`,
+    );
+  }
+  if (people.length > 1 && (options.displayName !== undefined || options.subjectId !== undefined)) {
+    throw new Error(
+      `${String(people.length)} legacy people were found, so --name and --subject cannot choose one. Point the command at a single person directory instead.`,
+    );
+  }
+  const single = people.length === 1 ? people[0] : undefined;
+  const displayName = options.displayName ?? single?.displayName;
+  const outcomes: {
+    readonly directory: string;
+    readonly displayName: string;
+    readonly subjectId?: string;
+    readonly ingested: number;
+  }[] = [];
+  const failures: string[] = [];
+  for (const person of people) {
+    io.stdout.write(`\n${person.displayName} (${person.directory})\n`);
+    for (const note of person.descriptorNotes) io.stdout.write(`  ${note}\n`);
+    if (!person.described) {
+      io.stdout.write("  No meta.json was read; the directory name was used as the name.\n");
+    }
+    const selection = await selectHarvestFiles(person.directory);
+    for (const line of describeHarvestSelection(selection)) io.stdout.write(`  ${line}\n`);
+    if (selection.files.length === 0) {
+      io.stdout.write("  No supported evidence file was found; this person was skipped.\n");
+      failures.push(`${person.displayName}: no supported evidence file`);
+      continue;
+    }
+    const isSingle = single !== undefined;
+    // Every person keeps its own name; only a single-directory import can override it, and only
+    // a single-directory import may target an existing subject.
+    const personName = isSingle && displayName !== undefined ? displayName : person.displayName;
+    const personSubjectId = isSingle ? options.subjectId : undefined;
+    const personAliases = options.displayName === undefined ? person.aliases : [];
+    try {
+      const outcome = await ingestFileSelection(
+        {
+          command: "import",
+          host: options.host,
+          files: selection.files,
+          force: options.force,
+          ...(personSubjectId === undefined
+            ? { displayName: personName }
+            : { subjectId: personSubjectId }),
+          ...(personAliases.length === 0 ? {} : { aliases: personAliases }),
+          ...(options.sensitivity === undefined ? {} : { sensitivity: options.sensitivity }),
+          ...(options.maximumFiles === undefined ? {} : { maximumFiles: options.maximumFiles }),
+        },
+        environment,
+        io,
+      );
+      outcomes.push({
+        directory: person.directory,
+        displayName: personName,
+        ...(outcome.subjectId === undefined ? {} : { subjectId: outcome.subjectId }),
+        ingested: outcome.ingested,
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : "unknown failure";
+      failures.push(`${person.displayName}: ${reason}`);
+      io.stdout.write(`  Could not import ${person.displayName}: ${reason}\n`);
+    }
+  }
+  if (options.asJson) {
+    io.stdout.write(`${JSON.stringify({ people: outcomes, failures }, undefined, 2)}\n`);
+  } else {
+    io.stdout.write(
+      `\nImported ${String(outcomes.length)} of ${String(people.length)} legacy person(s).\n`,
+    );
+    for (const outcome of outcomes) {
+      io.stdout.write(
+        `  ${outcome.displayName} -> ${outcome.subjectId ?? "(unchanged target)"} (${String(outcome.ingested)} file(s))\n`,
+      );
+    }
+    io.stdout.write(
+      "Next: ask the host that has Distilly installed to distill these people, then review the profiles with distilly show.\n",
+    );
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `${String(failures.length)} of ${String(people.length)} legacy person(s) could not be imported:\n${failures.join("\n")}`,
+    );
+  }
+};
+
 const help = `Distilly Developer Preview
 
 Usage:
@@ -1032,6 +1280,8 @@ Usage:
   distilly setup --host claude-code|openclaw|hermes|dsh [--allow-unverified-host]
   distilly doctor [--host <host>]
   distilly install <subject-id|display-name> --host <host>
+  distilly import <legacy-directory> --host <host> [--name <display-name>|--subject <id>]
+                  [--sensitivity private|shareable] [--limit <n>] [--force] [--json]
   distilly versions <subject-id|display-name> --host <host> [--limit <n>] [--cursor <cursor>] [--json]
   distilly diff <subject-id|display-name> --host <host> --from <version> --to <version> [--json]
   distilly rollback <subject-id|display-name> --host <host> --to <version> [--reason <text>]
@@ -1113,6 +1363,10 @@ export const runPreviewCli = async (
     } finally {
       await application.close();
     }
+    return 0;
+  }
+  if (command === "import") {
+    await runImport(args, environment, io);
     return 0;
   }
   if (command === "versions") {

--- a/packages/engine/src/ingest/normalize.test.ts
+++ b/packages/engine/src/ingest/normalize.test.ts
@@ -62,6 +62,20 @@ describe("material normalization v1", () => {
     expect(normalizeMaterialTextV1("\ufeff")).toBe("\ufeff");
   });
 
+  it("canonicalizes a long run of spaces or tabs in linear time", () => {
+    // The previous regular expression retried the whole run at every position, so a single
+    // megabyte of spaces took minutes and made the whole ingest call appear to hang.
+    for (const filler of [" ".repeat(700_000), "\t".repeat(200_000), "\u00a0".repeat(500_000)]) {
+      const text = `a${filler}b`;
+      const started = Date.now();
+      const normalized = normalizeMaterialTextV1(text);
+      expect(Date.now() - started).toBeLessThan(2_000);
+      expect(normalized === text).toBe(true);
+    }
+    const trailing = `${"a".repeat(500_000)}${" ".repeat(300_000)}`;
+    expect(normalizeMaterialTextV1(trailing)).toBe("a".repeat(500_000));
+  });
+
   it("reapplies content and provenance byte bounds after NFC expansion", () => {
     const expandingLabel = `${"x".repeat(WIRE_LIMITS.labelBytes - 2)}\u0344`;
     const expandingContent = `${"x".repeat(WIRE_LIMITS.materialContentBytes - 2)}\u0344`;

--- a/packages/engine/src/ingest/normalize.ts
+++ b/packages/engine/src/ingest/normalize.ts
@@ -83,14 +83,61 @@ const normalizeArtifact = (
  * @returns The canonical material body.
  */
 const normalizeTextV1 = (value: string, maximumBytes: number, fieldPath: string): string => {
-  const normalized = value
-    .replace(/\r\n?/g, "\n")
-    .normalize("NFC")
-    .replace(/[ \t]+(?=\n|$)/g, "");
+  const normalized = canonicalizeMaterialText(value);
   if (!/[^\p{White_Space}]/u.test(normalized)) {
     throw invalidInput("Canonical text cannot be whitespace-only.", fieldPath);
   }
   return enforceCanonicalUtf8Limit(normalized, maximumBytes, fieldPath);
+};
+
+/**
+ * Applies the frozen material-text-v1 canonicalization without any size or content check.
+ *
+ * The trailing-whitespace rule is implemented as a single forward scan rather than a
+ * back-tracking regular expression: `/[ \t]+(?=\n|$)/` retries the whole run at every
+ * position of a long run, which made a file with a megabyte of spaces take minutes. Splitting
+ * a large parsed text needs exactly this canonical form (so a part is stored unchanged), and
+ * it must be linear for the same reason.
+ *
+ * @param value - Raw material text.
+ * @returns Canonical text: CRLF and CR to LF, NFC, and no spaces or tabs before a line end.
+ */
+export const canonicalizeMaterialText = (value: string): string => {
+  const lineEnded = value.includes("\r") ? value.replace(/\r\n?/g, "\n") : value;
+  const composed = lineEnded.normalize("NFC");
+  return stripTrailingHorizontalWhitespace(composed);
+};
+
+/**
+ * Removes spaces and tabs that sit immediately before a newline or the end of the text.
+ *
+ * @param text - Text already converted to LF line endings and NFC.
+ * @returns Text without trailing horizontal whitespace.
+ */
+const stripTrailingHorizontalWhitespace = (text: string): string => {
+  const pieces: string[] = [];
+  let copyFrom = 0;
+  let index = 0;
+  while (index < text.length) {
+    const code = text.charCodeAt(index);
+    if (code !== 0x20 && code !== 0x09) {
+      index += 1;
+      continue;
+    }
+    let runEnd = index;
+    while (runEnd < text.length) {
+      const runCode = text.charCodeAt(runEnd);
+      if (runCode !== 0x20 && runCode !== 0x09) break;
+      runEnd += 1;
+    }
+    const next = runEnd < text.length ? text.charCodeAt(runEnd) : -1;
+    if (next === 0x0a || next === -1) {
+      pieces.push(text.slice(copyFrom, index));
+      copyFrom = runEnd;
+    }
+    index = runEnd;
+  }
+  return pieces.length === 0 ? text : `${pieces.join("")}${text.slice(copyFrom)}`;
 };
 
 /**

--- a/packages/engine/src/preview.ts
+++ b/packages/engine/src/preview.ts
@@ -554,6 +554,8 @@ class PreviewEngineRuntimeImplementation implements PreviewEngineRuntime {
  * @param options - Root owned exclusively by this in-process runtime.
  * @returns The opened Preview runtime.
  */
+export { canonicalizeMaterialText } from "./ingest/normalize.js";
+
 export const openPreviewEngine = async (
   options: OpenPreviewEngineOptions,
 ): Promise<PreviewEngineRuntime> => {

--- a/packages/runtime/src/preview.test.ts
+++ b/packages/runtime/src/preview.test.ts
@@ -687,6 +687,32 @@ describe("local record budget", () => {
   });
 });
 
+describe("unsplittable parsed text", () => {
+  it("keeps the raw file and warns when a whitespace run cannot become a legal part", async () => {
+    const root = await temporaryRoot();
+    const inputRoot = await temporaryRoot();
+    const path = join(inputRoot, "spaces.txt");
+    // One 1.2 MiB run of spaces is longer than a material, so no legal part exists; the file
+    // must be kept as raw evidence with a warning instead of failing the whole call.
+    await writeFile(path, `a${" ".repeat(1_200_000)}b\n`);
+
+    const runtime = await open(root);
+    const client = await connect(runtime, "unsplittable");
+    const result = await client.call(
+      "materials.ingestFiles",
+      {
+        subject: { kind: "create" as const, input: { displayName: "Spaces", identityHints: [] } },
+        paths: [path],
+        enqueue: "now" as const,
+      },
+      { requestId: request() },
+    );
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.kind).toBe("unparsed");
+    expect(result.items[0]?.warnings.join(" ")).toContain("whitespace longer than one material");
+  });
+});
+
 describe("split reassembly through the engine", () => {
   it("briefs every part of a split file and reproduces the parsed text byte for byte", async () => {
     const root = await temporaryRoot();

--- a/packages/runtime/src/preview.ts
+++ b/packages/runtime/src/preview.ts
@@ -221,10 +221,24 @@ const createLocalFileLoader = () => {
             new TextEncoder().encode(parsed.material.content).byteLength >
               WIRE_LIMITS.materialContentBytes
           ) {
-            const parts = splitParsedText(
-              parsed.material.content,
-              WIRE_LIMITS.materialContentBytes,
-            );
+            let parts: readonly string[];
+            try {
+              parts = splitParsedText(parsed.material.content, WIRE_LIMITS.materialContentBytes);
+            } catch (error) {
+              // A whitespace run larger than one material cannot become a legal part. Keep the
+              // raw file and warn, so one pathological file cannot fail the whole selection.
+              return {
+                pathLabel,
+                mediaType,
+                bytes,
+                source,
+                warnings: [
+                  error instanceof DistillyError
+                    ? error.message
+                    : "The parsed text could not be split into materials.",
+                ],
+              };
+            }
             if (parts.length > WIRE_LIMITS.ingestMaterials) {
               // More parts than one ingest call can carry: refuse rather than drop any.
               return {

--- a/packages/runtime/src/split-parsed-text.test.ts
+++ b/packages/runtime/src/split-parsed-text.test.ts
@@ -1,3 +1,4 @@
+import { canonicalizeMaterialText } from "@distilly/engine/preview";
 import { describe, expect, it } from "vitest";
 
 import { splitParsedText } from "./split-parsed-text.js";
@@ -6,26 +7,21 @@ const encoder = new TextEncoder();
 const bytes = (text: string): number => encoder.encode(text).byteLength;
 const maximumBytes = 1_048_576;
 
-/**
- * Mirrors the engine's frozen material-text-v1 canonicalization so parts can be checked.
- *
- * @param text - Text to canonicalize.
- * @returns Canonical text.
- */
-const canonicalize = (text: string): string =>
-  text
-    .replace(/\r\n?/gu, "\n")
-    .normalize("NFC")
-    .replace(/[ \t]+(?=\n|$)/gu, "");
+/** The engine's own canonicalization, so a test cannot drift from what is stored. */
+const canonicalize = canonicalizeMaterialText;
 
 const expectPartsOfCanonicalText = (text: string, parts: readonly string[]): void => {
   const canonical = canonicalize(text);
-  expect(parts.join("")).toBe(canonical);
+  const joined = parts.join("");
+  // Compare lengths first: a failing byte-equality assertion on a megabyte string makes the
+  // test runner print a megabyte diff, which reads as a hang instead of a failure.
+  expect(joined.length).toBe(canonical.length);
+  expect(joined === canonical).toBe(true);
   for (const part of parts) {
     expect(part.length).toBeGreaterThan(0);
     expect(bytes(part)).toBeLessThanOrEqual(maximumBytes);
     // A part is stored unchanged only when it already equals its own canonical form.
-    expect(canonicalize(part)).toBe(part);
+    expect(canonicalize(part) === part).toBe(true);
   }
 };
 
@@ -69,8 +65,8 @@ describe("parsed text splitting", () => {
     const text = line.repeat(maximumBytes / line.length);
     expect(bytes(text)).toBe(maximumBytes);
     const parts = splitParsedText(text, maximumBytes);
-    expect(parts).toEqual([text]);
-    expect(parts.some((part) => part.length === 0)).toBe(false);
+    expect(parts.length).toBe(1);
+    expect(parts[0] === text).toBe(true);
 
     const doubled = text.repeat(2);
     const doubledParts = splitParsedText(doubled, maximumBytes);
@@ -84,9 +80,11 @@ describe("parsed text splitting", () => {
     expectPartsOfCanonicalText(text, parts);
     for (const part of parts) expect(loneSurrogates(part)).toBe(0);
     // Round-tripping through UTF-8 must not introduce a replacement character.
-    expect(parts.map((part) => new TextDecoder().decode(encoder.encode(part))).join("")).toBe(
-      canonicalize(text),
-    );
+    const roundTripped = parts
+      .map((part) => new TextDecoder().decode(encoder.encode(part)))
+      .join("");
+    expect(roundTripped.length).toBe(canonicalize(text).length);
+    expect(roundTripped === canonicalize(text)).toBe(true);
     expect(parts.join("")).not.toContain("\uFFFD");
   });
 
@@ -98,7 +96,7 @@ describe("parsed text splitting", () => {
       const parts = splitParsedText(text, 4);
       expect(Date.now() - started).toBeLessThan(1_000);
       for (const part of parts) expect(bytes(part)).toBeLessThanOrEqual(4);
-      expect(parts.join("")).toBe(canonicalize(text));
+      expect(parts.join("") === canonicalize(text)).toBe(true);
     }
 
     const long = `a${"\u0301".repeat(600_000)}`;
@@ -117,7 +115,7 @@ describe("parsed text splitting", () => {
       timings.push(Date.now() - started);
       expect(parts).toHaveLength(mebibytes);
       expect(parts.every((part) => bytes(part) === maximumBytes)).toBe(true);
-      expect(parts.join("")).toBe(text);
+      expect(parts.join("") === text).toBe(true);
     }
     // Linear growth means doubling the input roughly doubles the work; the previous
     // implementation re-scanned the whole remaining line for each part.
@@ -165,7 +163,57 @@ describe("parsed text splitting", () => {
     const text = "ab😀cd\u0301ef\ngh";
     const parts = splitParsedText(text, 4);
     for (const part of parts) expect(bytes(part)).toBeLessThanOrEqual(4);
-    expect(parts.join("")).toBe(canonicalize(text));
+    expect(parts.join("") === canonicalize(text)).toBe(true);
+  });
+
+  it("terminates and stays byte-exact on long runs of spaces or tabs", () => {
+    // These shapes hung or silently dropped bytes before: the canonicalization regular
+    // expression backtracked over the whole run, and a bounded cut back-off left spaces at a
+    // part end that the engine then stripped.
+    for (const filler of [" ".repeat(2_000), "\t".repeat(32_000), " ".repeat(700_000)]) {
+      const text = `a${filler}b`;
+      const started = Date.now();
+      const parts = splitParsedText(text, maximumBytes);
+      expect(Date.now() - started).toBeLessThan(2_000);
+      expectPartsOfCanonicalText(text, parts);
+    }
+
+    const atCut = `${"a".repeat(maximumBytes - 36)}${" ".repeat(40)}b`;
+    const parts = splitParsedText(atCut, maximumBytes);
+    expectPartsOfCanonicalText(atCut, parts);
+    expect(parts.join("") === atCut).toBe(true);
+
+    const tabsAtCut = `${"a".repeat(maximumBytes - 36)}${"\t".repeat(40)}b`;
+    const tabParts = splitParsedText(tabsAtCut, maximumBytes);
+    expectPartsOfCanonicalText(tabsAtCut, tabParts);
+    expect(tabParts.join("") === tabsAtCut).toBe(true);
+  });
+
+  it("refuses a whitespace run no legal part could hold instead of failing the call", () => {
+    for (const text of [
+      `a${" ".repeat(maximumBytes + 24)}b`,
+      `a${"\u00a0".repeat(1_200_000)}b`,
+      "\n".repeat(maximumBytes + 1),
+    ]) {
+      expect(() => splitParsedText(text, maximumBytes)).toThrowError(
+        /whitespace longer than one material/u,
+      );
+    }
+  });
+
+  it("never separates a combining mark from the base it modifies", () => {
+    const filler = `${"a".repeat(63)}\n`.repeat(16_383);
+    const text = `${filler}\u0301${"b".repeat(99)}\n`;
+    const parts = splitParsedText(text, maximumBytes);
+    expectPartsOfCanonicalText(text, parts);
+    for (let index = 1; index < parts.length; index += 1) {
+      const first = parts[index]?.codePointAt(0) ?? 0;
+      if (!/^\p{M}$/u.test(String.fromCodePoint(first))) continue;
+      // A part may begin with a mark only when the mark run continues from the part before it.
+      const previous = parts[index - 1] ?? "";
+      const last = previous.codePointAt(previous.length - 1) ?? 0;
+      expect(/^\p{M}$/u.test(String.fromCodePoint(last))).toBe(true);
+    }
   });
 
   it("returns no parts for empty text", () => {

--- a/packages/runtime/src/split-parsed-text.ts
+++ b/packages/runtime/src/split-parsed-text.ts
@@ -1,28 +1,29 @@
+import { canonicalizeMaterialText } from "@distilly/engine/preview";
+import { DistillyError } from "@distilly/protocol";
+
 /**
  * Splits one oversized parsed text into parts that each fit the local material byte limit.
  *
- * The text is first canonicalized exactly the way the engine canonicalizes stored material
- * (CRLF/CR to LF, NFC, trailing spaces and tabs before a line end removed), so a part is stored
- * unchanged and a mid-line cut cannot create a seam the engine would rewrite. Parts are then
+ * The text is first canonicalized by the engine's own material-text-v1 rule (CRLF and CR to
+ * LF, NFC, and no spaces or tabs before a line end), so a stored part equals the slice that
+ * produced it and a mid-line cut cannot create a seam the engine would rewrite. Parts are then
  * consecutive slices of that canonical text: joining them with an empty string reproduces it,
  * no byte is added or dropped, and no part is empty.
  *
  * A cut prefers a line boundary. Only a single line that cannot fit in one part is cut inside
  * the line, at a Unicode code point boundary, never between a high and a low surrogate, never
- * immediately before a combining mark, and never where the part would end in spaces or tabs
- * that the engine would strip. The scan is linear in the text length, including for a single
- * line larger than the limit.
+ * between a base character and its combining marks, and never inside a run of spaces or tabs.
+ * The scan is linear in the text length, including for one line larger than the limit.
  *
  * @param text - Rendered material text.
  * @param maximumBytes - Largest UTF-8 byte length one part may have.
  * @returns One or more part texts, in order; no parts for empty text.
+ * @throws DistillyError when the text contains a whitespace run no legal part could hold.
  */
 export const splitParsedText = (text: string, maximumBytes: number): readonly string[] => {
   if (maximumBytes < 4) throw new Error("A part must be able to hold one code point.");
-  const canonical = text
-    .replace(/\r\n?/gu, "\n")
-    .normalize("NFC")
-    .replace(/[ \t]+(?=\n|$)/gu, "");
+  const canonical = canonicalizeMaterialText(text);
+  assertNoOversizedWhitespaceRun(canonical, maximumBytes);
   const parts: string[] = [];
   let partStart = 0;
   let partBytes = 0;
@@ -64,9 +65,9 @@ export const splitParsedText = (text: string, maximumBytes: number): readonly st
         end += codePoint > 0xffff ? 2 : 1;
       }
       if (end === index) throw new Error("A part must be able to hold one code point.");
-      const cut = trimCut(canonical, index, end, lineEnd, bytes);
-      parts.push(canonical.slice(index, cut.end));
-      index = cut.end;
+      const cut = trimCut(canonical, index, end);
+      parts.push(canonical.slice(index, cut));
+      index = cut;
     }
     partStart = index;
     cursor = index;
@@ -76,20 +77,70 @@ export const splitParsedText = (text: string, maximumBytes: number): readonly st
   return parts;
 };
 
-/** Matches one combining mark, which must not be the first code point of a part. */
+/** Matches one combining mark, which must not be separated from the base it modifies. */
 const COMBINING_MARK = /^\p{M}$/u;
 
 /**
- * Largest number of code points a cut may move back to avoid a seam the engine would rewrite.
+ * Reports whether one code point is whitespace the engine would reject a part for.
  *
- * The bound keeps the scan linear when a pathological line is one long run of combining marks
- * or spaces: past it the cut is taken as computed, which can leave a detached mark or a
- * stripped space in that one place instead of scanning the whole run again for every part.
+ * @param code - UTF-16 code unit or code point value.
+ * @returns True for the Unicode White_Space set.
  */
-const MAXIMUM_CUT_BACKOFF = 32;
+const isEngineWhitespace = (code: number): boolean =>
+  (code >= 0x09 && code <= 0x0d) ||
+  code === 0x20 ||
+  code === 0x85 ||
+  code === 0xa0 ||
+  code === 0x1680 ||
+  (code >= 0x2000 && code <= 0x200a) ||
+  code === 0x2028 ||
+  code === 0x2029 ||
+  code === 0x202f ||
+  code === 0x205f ||
+  code === 0x3000;
 
-/** Matches the whitespace the engine strips at the end of a part. */
-const TRIMMED_AT_PART_END = /^[ \t]$/u;
+/**
+ * Reports whether one code point is the horizontal whitespace the engine strips at a part end.
+ *
+ * @param code - UTF-16 code unit or code point value.
+ * @returns True for space or tab.
+ */
+const isHorizontalWhitespace = (code: number): boolean => code === 0x20 || code === 0x09;
+
+/**
+ * Refuses text whose whitespace run is longer than any legal part could hold.
+ *
+ * A part made only of whitespace is rejected by the engine, so a run longer than the limit
+ * cannot be split into legal materials at all. Refusing here lets the caller keep the raw file
+ * and warn, instead of failing the whole ingest call with a bare canonicalization error.
+ *
+ * @param text - Canonical text.
+ * @param maximumBytes - Largest UTF-8 byte length one part may have.
+ */
+const assertNoOversizedWhitespaceRun = (text: string, maximumBytes: number): void => {
+  let runBytes = 0;
+  let index = 0;
+  while (index < text.length) {
+    const codePoint = text.codePointAt(index) ?? 0;
+    if (isEngineWhitespace(codePoint)) {
+      runBytes += utf8Width(codePoint);
+      if (runBytes > maximumBytes) {
+        throw new DistillyError({
+          code: "context_too_large",
+          message:
+            "Parsed text contains a run of whitespace longer than one material, which cannot be split into legal parts.",
+          retryable: false,
+          fieldPath: "material.content",
+          remediation: "Narrow the selected file and try again.",
+          details: { maximumBytes, whitespaceRunBytes: runBytes },
+        });
+      }
+    } else {
+      runBytes = 0;
+    }
+    index += codePoint > 0xffff ? 2 : 1;
+  }
+};
 
 /**
  * Moves a line-boundary cut forward over combining marks that begin the next line.
@@ -122,40 +173,30 @@ const extendOverMarks = (
 /**
  * Chooses where a mid-line cut ends so the stored part equals the slice.
  *
- * A part must not end in spaces or tabs (the engine strips them) and the next part must not
- * begin with a combining mark, but a part always keeps at least one code point so the scan
- * always advances.
+ * The cut moves back while it would separate a base character from its combining marks or
+ * leave spaces or tabs at the end of the part, which the engine would strip. It always keeps
+ * at least one code point, so the scan advances even for pathological input; a whitespace run
+ * longer than a part is refused before splitting rather than silently trimmed.
  *
  * @param text - Canonical text.
  * @param start - First index of the part.
  * @param end - Largest index that fits the byte ceiling.
- * @param lineEnd - Exclusive end of the line being cut.
- * @param bytes - Byte length of the untrimmed slice.
- * @returns The chosen end index and its byte length.
+ * @returns The chosen end index.
  */
-const trimCut = (
-  text: string,
-  start: number,
-  end: number,
-  lineEnd: number,
-  bytes: number,
-): { readonly end: number; readonly bytes: number } => {
-  let trimmedEnd = end;
-  let trimmedBytes = bytes;
-  let steps = 0;
-  while (trimmedEnd < lineEnd && trimmedEnd > start && steps < MAXIMUM_CUT_BACKOFF) {
-    const next = text.codePointAt(trimmedEnd) ?? 0;
-    const previousStart = previousCodePointStart(text, trimmedEnd, start);
-    if (previousStart <= start) break;
+const trimCut = (text: string, start: number, end: number): number => {
+  let cut = end;
+  while (cut > start) {
+    const after = text.codePointAt(cut);
+    const previousStart = previousCodePointStart(text, cut, start);
     const previous = text.codePointAt(previousStart) ?? 0;
-    const startsWithMark = COMBINING_MARK.test(String.fromCodePoint(next));
-    const endsWithTrimmed = TRIMMED_AT_PART_END.test(String.fromCodePoint(previous));
-    if (!startsWithMark && !endsWithTrimmed) break;
-    trimmedEnd = previousStart;
-    trimmedBytes -= utf8Width(previous);
-    steps += 1;
+    const detachesMark =
+      after !== undefined &&
+      COMBINING_MARK.test(String.fromCodePoint(after)) &&
+      !COMBINING_MARK.test(String.fromCodePoint(previous));
+    if (!detachesMark && !isHorizontalWhitespace(previous)) break;
+    cut = previousStart;
   }
-  return { end: trimmedEnd, bytes: trimmedBytes };
+  return cut === start ? end : cut;
 };
 
 /**


### PR DESCRIPTION
## What
fix/feat: real DSH home, linear canonicalization, legacy Skill import

## Commits
- fix(dsh,runtime,engine): reach the real DSH home and stop hanging on long runs
- feat(cli): import a legacy Skill store as Distilly material
- fix(cli): never merge two legacy people, and keep import output machine-readable

## Stack
Stacked on `pr/09-versions-and-person-skill`; the whole series ends at `distilly-work` (`0bd924e`).

## Verification
Every feature carries an author report and an independent audit in the delivery evidence folder (`host-verification/`), including screenshots and the audit verdict that drove the fixes. Gates on the top of the stack: format, lint, docs, release check, and 1163 tests.

## Real hosts
Codex, Claude Code 2.1.268, OpenClaw 2026.9.2, Hermes v0.19.0, and DSH 0.1.5-rc.1 were each exercised end to end (install, host-visible confirmation, exactly five MCP tools, person Skill install/remove, uninstall). Capacity fixtures are recorded for Codex 0.146.0, OpenClaw 2026.3.24, and Hermes v0.9.0; newer host versions run on the labelled conservative floor.

## Evidence
Author reports and screenshots (delivery evidence folder `host-verification/`):
- f14-dsh-host-integration-REPORT.md, f14-dsh-host-integration.png
- f16-legacy-import-REPORT.md, f16-legacy-import.png, f18-import-integrity-REPORT.md, f18-import-integrity.png

Independent audit reports:
- round15-legacy-import-VERIFY.md, round16-import-integrity-VERIFY.md