### PR TITLE
docs: verified host status; feat(release): one release tuple check

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,14 +49,45 @@ node packages/cli/lib/bin.js uninstall --host codex
 
 This removes Distilly's verified host Plugin and runtime projection. It keeps `~/.distilly/` person data, source materials, profiles, and separately installed person Skills. A modified or foreign installation is left untouched and reported for manual review.
 
-## OpenClaw and Hermes compatibility bindings
+## Claude Code, OpenClaw, Hermes, and DSH bindings
 
-The Preview includes local lifecycle bindings for two additional hosts:
+Each supported host installs its own owned projection and can be removed without touching person data:
 
-- **OpenClaw:** installs a Claude-compatible bundle at `~/.openclaw/extensions/distilly` with an owned `.mcp.json`. Verify discovery with `openclaw plugins inspect distilly --json`.
+- **Claude Code:** installs a skills-directory plugin at `~/.claude/skills/distilly`. Verify with `claude plugin list` (the plugin must be `loaded`) and `claude mcp list` (the distilly server must be `Connected`).
+- **OpenClaw:** installs a Claude-compatible bundle at `~/.openclaw/extensions/distilly` with an owned `.mcp.json`. Verify discovery with `openclaw plugins inspect distilly` and `openclaw skills list`.
 - **Hermes:** installs the canonical Skill at `~/.hermes/skills/distilly`, a managed wrapper at `~/.distilly/bin/distilly-hermes`, and the `distilly` MCP entry in `~/.hermes/config.yaml`. The optional `resources` and `prompts` surfaces are disabled; verify five tools with `hermes mcp test distilly`.
+- **DeepSeek Harness:** owns a profile under `$DSH_HOME/profiles/distilly` (default `~/.dsh`), which the harness composes from its own layers plus our patch. Verify with `dsh --profile distilly --dump-config`. Note that the harness home is `$DSH_HOME`, not the ordinary user home.
 
-The CLI accepts `setup --host openclaw` and `setup --host hermes` when their installed versions match the recorded real-host transport fixtures: OpenClaw `2026.3.24` has a 65,536-byte net budget and Hermes `v0.9.0` has a 49,752-byte net budget. These measurements use a deterministic synthetic fixture server through the real host executable, `openai-codex/gpt-5.4`, and MCP transport in an isolated clean session; they prove the recorded briefing/tool-result path, not the complete packaged lifecycle. Unknown versions or changed release/tool tuples return `host_unsupported` before writing files. Setup never falls back to `dot-skill` automatically.
+`setup --host <host>` verifies the installed host version against a recorded real-host transport fixture before writing anything:
+
+| Host version | Recorded net budget |
+| --- | --- |
+| Codex `0.146.0` | 65,536 bytes |
+| OpenClaw `2026.3.24` | 65,536 bytes |
+| Hermes `v0.9.0` | 49,752 bytes |
+
+Those measurements use a deterministic synthetic fixture server through the real host executable, `openai-codex/gpt-5.4`, and MCP transport in an isolated clean session; they prove the recorded briefing/tool-result path.
+
+A host version with no recorded fixture stops setup with `host_unsupported` before any file is written and names both ways forward: install a version that has a fixture, or re-run with `--allow-unverified-host` to install on the conservative floor. That flag is an explicit operator decision: the install is recorded as unverified, `doctor` keeps reporting it, and it never falls back to `dot-skill` automatically.
+
+## The direct-user commands
+
+The same CLI works on every host without going through the model:
+
+```bash
+node packages/cli/lib/bin.js harvest <directory> --host codex --name "<display name>"
+node packages/cli/lib/bin.js subjects --host codex
+node packages/cli/lib/bin.js show "<subject id or name>" --host codex
+node packages/cli/lib/bin.js versions "<subject id or name>" --host codex
+node packages/cli/lib/bin.js diff "<subject id or name>" --host codex --from <version> --to <version>
+node packages/cli/lib/bin.js rollback "<subject id or name>" --host codex --to <version>
+node packages/cli/lib/bin.js install "<subject id or name>" --host codex
+node packages/cli/lib/bin.js personas --host codex
+node packages/cli/lib/bin.js remove "<subject id or name>" --host codex
+node packages/cli/lib/bin.js import <legacy skills directory> --host codex
+```
+
+`harvest` is safe to repeat: a file whose bytes this person already stored is skipped unless `--force` is given, and a second harvest for the same name adds to the same subject. `import` reads a store written by the older `dot-skill` release and never modifies it. `rollback` creates a new current version from an earlier one, so history is never rewritten.
 
 ## Run the packaged preview
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ On Codex, the complete flow below is verified. OpenClaw `2026.3.24` and Hermes `
 7. lets you promote, reject, or roll back the candidate in the local Panel; and
 8. installs the approved profile as a self-contained host Skill when you ask it to.
 
+The direct-user surface around that flow is the same CLI on every host:
+
+| Command | What it does |
+| --- | --- |
+| `distilly harvest <directory> --host <host> --name <name>` | stores a directory of local files as evidence, queues distillation, and is safe to repeat: a file whose bytes this person already stored is skipped, `--force` re-ingests it |
+| `distilly import <directory> --host <host>` | migrates a store written by the older `dot-skill` release (a person folder, or a `skills/` tree of them) without modifying it |
+| `distilly subjects --host <host>` | lists what this store knows, so no one has to remember a subject id |
+| `distilly show <subject-id\|name> --host <host>` | prints the profile, its maturity, covered and missing core facets, and what material would cover each gap |
+| `distilly versions` / `diff` / `rollback` | reads immutable version history, shows the semantic difference between two versions, and restores an earlier one as a new current version |
+| `distilly install <subject-id\|name> --host <host>` | installs the profile as a person Skill; re-running after a re-distill updates it in place |
+| `distilly personas` / `remove` | lists the person Skills installed for a host and removes one without touching the host integration |
+
 The model-facing surface remains exactly five MCP tools:
 
 `distilly_get` · `distilly_ingest` · `distilly_pending` · `distilly_commit` · `distilly_correct`
@@ -106,10 +118,10 @@ Distilly never silently truncates a complete briefing or profile prompt. If a ve
 | Host | Native Plugin | Current compatibility route |
 | --- | --- | --- |
 | Codex | Fully verified in this release branch | Native Plugin |
-| Claude Code | Binding included; exact host fixture still needed | Explicit `dot-skill` Legacy Skill |
-| OpenClaw | Transport-capacity fixture recorded for `2026.3.24` (65,536-byte net budget); lifecycle pending | Claude-compatible bundle + discovery smoke |
-| Hermes | Transport-capacity fixture recorded for `v0.9.0` (49,752-byte net budget); lifecycle pending | Managed Skill + MCP configuration |
-| DeepSeek Harness (DSH) | Community binding planned | Explicit `dot-skill` Legacy Skill |
+| Claude Code | Binding verified against the real `2.1.268` binary: the host loads the plugin and reports our MCP server connected. No capacity fixture for that version yet, so setup needs `--allow-unverified-host` and runs on the conservative floor | Native Plugin |
+| OpenClaw | Binding verified against the real `2026.9.2` binary: the host loads the bundle with `skills` + `mcpServers` and lists the Skill as ready. Capacity fixture recorded for `2026.3.24` (65,536-byte net budget); a fixture for `2026.9.2` still needs a measured model session | Native Plugin |
+| Hermes | Lifecycle verified against a real `v0.19.0` install: install, doctor, MCP tool surface, persona install, and uninstall. Capacity fixture recorded for `v0.9.0` (49,752-byte net budget); the newer version runs on the conservative floor with an explicit `--allow-unverified-host` | Native Plugin |
+| DeepSeek Harness (DSH) | Binding verified against the real harness: `dsh --profile distilly --dump-config` mounts our server, the MCP handshake exposes exactly five tools, and the full install/persona/uninstall cycle passes. No measured capacity fixture yet, so setup needs `--allow-unverified-host` | Native Plugin |
 | Pi agent | Community binding planned | Explicit `dot-skill` Legacy Skill |
 | Grok Build | Community binding planned | Explicit `dot-skill` Legacy Skill |
 | OpenCode | Community binding planned | Explicit `dot-skill` Legacy Skill |
@@ -119,7 +131,11 @@ Host compatibility is a binding concern. Legacy Skill discovery is useful contin
 
 ## Local material formats
 
-The first Preview accepts explicit local `TXT`, `Markdown`, `JSON`, and `SRT/VTT` files. It also accepts pasted text and public URLs through the host's visible research flow. Files are read only from the paths or sources the user supplies; symlinked selected files and duplicate file names are rejected. PDF, email, provider exports, and hosted connectors are follow-up work.
+The Preview accepts explicit local `TXT`, `Markdown`, `JSON`, `EML`, `MBOX`/`MBX`, and `SRT`/`VTT` files. JSON chat exports from ChatGPT, Claude, Telegram, Slack, and Discord are recognized structurally and stored as transcripts with their participants; a renamed export still works, every omission (branches outside the conversation path, attachments, textless messages) is reported, and the rendered text keeps each message verbatim so claims can quote it. Email containers are parsed with their attachments skipped and reported.
+
+A single parsed file larger than the per-material limit is split into consecutive parts at code point boundaries; joining the parts reproduces the canonical text, and a part never separates a character from its combining marks. A file whose whitespace run is longer than one material cannot become legal parts, so it is kept as raw evidence with a printed warning instead of failing the whole selection.
+
+It also accepts pasted text and public URLs through the host's visible research flow. Files are read only from the paths or sources the user supplies; symlinked selected files and duplicate file names are rejected, and a file the person already stored is skipped unless `--force` is given. A store written by the older `dot-skill` release can be migrated with `distilly import`. PDF and hosted connectors remain follow-up work.
 
 ## 📣 2026-09 update: help expand coding-agent Plugins
 

--- a/package.json
+++ b/package.json
@@ -19,16 +19,18 @@
     "test:boundaries": "node --test tests/check_package_boundaries.test.mjs",
     "test:build-artifacts": "node --test tests/build_artifacts.test.mjs",
     "test:plugins": "python3 -B -m unittest tests.test_assemble_plugins",
+    "test:release": "node --test tests/release_manifest.test.mjs",
     "check:boundaries": "node scripts/check_package_boundaries.mjs .",
     "check:engine-pack": "node scripts/check_engine_pack.mjs .",
     "check:plugins": "python3 -B scripts/assemble_plugins.py --check",
     "package:preview:codex": "pnpm run build && node packages/cli/scripts/assemble-preview-package.mjs --output artifacts/distilly-0.1.0-preview.1-codex --force",
     "snapshots": "pnpm -r --if-present run snapshots",
     "docs": "python3 -B scripts/verify_docs.py",
+    "release:check": "node scripts/check_release.mjs",
     "build": "node scripts/clean_build_outputs.mjs . && tsc -b --force",
     "smoke:built": "pnpm -r --if-present run smoke:built",
-    "hygiene": "pnpm run check:boundaries && pnpm run check:plugins && knip && pnpm run smoke:built && pnpm run check:engine-pack && pnpm -r exec publint && pnpm -r exec attw --pack --profile esm-only .",
-    "gates": "pnpm run gates:fast && pnpm run typecheck && pnpm run test && pnpm run test:coverage && pnpm run snapshots && pnpm run docs && pnpm run build && pnpm run hygiene"
+    "hygiene": "pnpm run release:check && pnpm run check:boundaries && pnpm run check:plugins && knip && pnpm run smoke:built && pnpm run check:engine-pack && pnpm -r exec publint && pnpm -r exec attw --pack --profile esm-only .",
+    "gates": "pnpm run gates:fast && pnpm run typecheck && pnpm run test && pnpm run test:coverage && pnpm run snapshots && pnpm run docs && pnpm run release:check && pnpm run build && pnpm run hygiene"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.5",

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1363,6 +1363,10 @@ Usage:
                    [--sensitivity private|shareable] [--limit <n>] [--force]
   # <host>: codex | claude-code | openclaw | hermes | dsh
 
+harvest --limit and import --limit cap the files ingested for one person per run.
+import reads a store written by the older dot-skill release and never modifies it.
+rollback creates a new current version from an earlier one; history is immutable.
+
 The host bindings share the same five-tool MCP contract. Setup remains
 fail-closed until this release has an exact verified capacity fixture for the
 selected host version; no synthetic capacity is used. --allow-unverified-host

--- a/scripts/check_release.mjs
+++ b/scripts/check_release.mjs
@@ -1,0 +1,200 @@
+// Release consistency check: one release tuple, verified against every artifact that names it.
+//
+// A release can go out with a capacity fixture that still names the previous version, a plugin
+// tree whose digest no longer matches the manifest, or no changelog entry at all. Each of those
+// breaks host setup for real users, so they are checked here instead of at first use.
+import { createHash } from "node:crypto";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The repository root is overridable so the consistency rules can be tested against a small
+// mutated copy instead of the real tree.
+const REPOSITORY_ROOT =
+  process.env.DISTILLY_RELEASE_ROOT ?? fileURLToPath(new URL("../", import.meta.url));
+const problems = [];
+const notes = [];
+
+const fail = (message) => problems.push(message);
+const note = (message) => notes.push(message);
+
+const canonicalize = (value) => {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, child]) => [key, canonicalize(child)]),
+    );
+  }
+  return value;
+};
+
+const canonicalJson = (value) => JSON.stringify(canonicalize(value));
+const sha256 = (bytes) => `sha256_${createHash("sha256").update(bytes).digest("hex")}`;
+
+const readJson = async (path) => JSON.parse(await readFile(path, "utf8"));
+
+/** Collects every regular file under one root, keyed by POSIX relative path. */
+const walkRegularFiles = async (root) => {
+  const files = new Map();
+  const walk = async (directory) => {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isSymbolicLink()) {
+        fail(`plugin source contains a symbolic link: ${relative(REPOSITORY_ROOT, path)}`);
+        continue;
+      }
+      if (entry.isDirectory()) {
+        await walk(path);
+        continue;
+      }
+      if (!entry.isFile()) {
+        fail(`plugin source contains a non-regular entry: ${relative(REPOSITORY_ROOT, path)}`);
+        continue;
+      }
+      files.set(relative(root, path).split(sep).join("/"), await readFile(path));
+    }
+  };
+  await walk(root);
+  return files;
+};
+
+const skillTreeDigest = (files) => {
+  const skillPrefix = "skills/distilly/";
+  const records = [...files.entries()]
+    .filter(([path]) => path.startsWith(skillPrefix))
+    .map(([path, bytes]) => ({
+      path: path.slice(skillPrefix.length),
+      contentDigest: sha256(bytes),
+    }))
+    .sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+  return sha256(Buffer.from(`canonical-skill-tree-v1\0${canonicalJson(records)}`, "utf8"));
+};
+
+const manifestPath = join(REPOSITORY_ROOT, "plugins", "release-manifest.json");
+const manifest = await readJson(manifestPath);
+const releaseVersion = manifest.releaseVersion;
+if (typeof releaseVersion !== "string" || releaseVersion.length === 0) {
+  fail("the release manifest has no releaseVersion");
+}
+
+// 1. The canonical Skill digest recorded in the manifest must match the shared Skill tree.
+const canonicalRoot = join(REPOSITORY_ROOT, manifest.canonicalSkill.root);
+const canonicalFiles = await walkRegularFiles(canonicalRoot);
+const computedCanonical = skillTreeDigest(
+  new Map([...canonicalFiles].map(([path, bytes]) => [`skills/distilly/${path}`, bytes])),
+);
+if (computedCanonical !== manifest.canonicalSkill.digest) {
+  fail(
+    `plugins/release-manifest.json canonicalSkill.digest is ${manifest.canonicalSkill.digest} but the tree hashes to ${computedCanonical}`,
+  );
+}
+for (const file of manifest.canonicalSkill.files ?? []) {
+  const bytes = canonicalFiles.get(file.path);
+  if (bytes === undefined) {
+    fail(`the canonical Skill tree is missing ${file.path}`);
+    continue;
+  }
+  if (sha256(bytes) !== file.contentDigest) {
+    fail(`the canonical Skill file ${file.path} no longer matches its recorded digest`);
+  }
+}
+
+// 2. Every recorded host target must still produce the recorded digests from its own tree.
+for (const target of manifest.targets ?? []) {
+  const root = join(REPOSITORY_ROOT, target.pluginRoot);
+  const files = await walkRegularFiles(root);
+  const digest = skillTreeDigest(files);
+  if (digest !== target.skillDigest) {
+    fail(
+      `${target.host}: plugins/release-manifest.json skillDigest is ${target.skillDigest} but ${target.pluginRoot} hashes to ${digest}`,
+    );
+  }
+  if (digest !== manifest.canonicalSkill.digest) {
+    fail(`${target.host}: the plugin Skill tree differs from the canonical Skill tree`);
+  }
+  const manifestBytes = files.get(
+    relative(root, join(REPOSITORY_ROOT, target.pluginManifestPath)).split(sep).join("/"),
+  );
+  if (manifestBytes === undefined) {
+    fail(`${target.host}: ${target.pluginManifestPath} is missing`);
+    continue;
+  }
+  const parsed = JSON.parse(Buffer.from(manifestBytes).toString("utf8"));
+  if (parsed.version !== releaseVersion) {
+    fail(
+      `${target.host}: ${target.pluginManifestPath} declares version ${parsed.version}, not ${releaseVersion}`,
+    );
+  }
+  if (sha256(manifestBytes) !== target.pluginManifestDigest) {
+    fail(`${target.host}: ${target.pluginManifestPath} no longer matches its recorded digest`);
+  }
+}
+
+// 3. Every capacity fixture must name this release and this Skill digest.
+const evidenceRoot = join(REPOSITORY_ROOT, "packages", "cli", "src", "evidence", "host-capacity");
+const fixtureNames = (await readdir(evidenceRoot).catch(() => [])).filter((name) =>
+  name.endsWith(".json"),
+);
+if (fixtureNames.length === 0) fail("no host capacity fixture is recorded");
+for (const name of fixtureNames.sort()) {
+  const fixture = await readJson(join(evidenceRoot, name));
+  if (fixture.releaseVersion !== releaseVersion) {
+    fail(
+      `${name} was measured for release ${fixture.releaseVersion}, not ${releaseVersion}; re-measure it or remove it`,
+    );
+  }
+  if (fixture.canonicalSkillDigest !== manifest.canonicalSkill.digest) {
+    fail(`${name} records a different canonical Skill digest than this release`);
+  }
+  if (fixture.boundKind !== undefined && fixture.capacity?.boundKind !== "verified_lower_bound") {
+    fail(`${name} must declare boundKind "verified_lower_bound"`);
+  }
+  if ((fixture.capacity?.estimatedInputTokens ?? 0) >= (fixture.capacity?.verifiedBriefingBytes ?? 0)) {
+    fail(`${name} claims a token budget that is not derived from its measured bytes`);
+  }
+}
+note(`${fixtureNames.length} capacity fixture(s) verified against ${releaseVersion}`);
+
+// 4. Every package that is meant to be published with this release carries its version.
+//    Private workspace packages stay at 0.0.0 by design and are only checked for a version field.
+const packageRoots = (await readdir(join(REPOSITORY_ROOT, "packages"), { withFileTypes: true }))
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+let published = 0;
+for (const name of packageRoots) {
+  const path = join(REPOSITORY_ROOT, "packages", name, "package.json");
+  const descriptor = await readJson(path);
+  if (descriptor.private === true) continue;
+  published += 1;
+  if (descriptor.version === "0.0.0") {
+    note(`packages/${name} is published but still at 0.0.0`);
+    continue;
+  }
+  if (descriptor.version !== releaseVersion) {
+    fail(`packages/${name}/package.json declares version ${descriptor.version}, not ${releaseVersion}`);
+  }
+}
+note(`${published} publishable package(s) checked`);
+
+// 5. The changelog must describe this release.
+const changelog = await readFile(join(REPOSITORY_ROOT, "CHANGELOG.md"), "utf8").catch(() => "");
+if (!changelog.includes(releaseVersion)) {
+  fail(`CHANGELOG.md has no section for ${releaseVersion}`);
+}
+
+// 6. The plugin manifest the DSH profile layer publishes must exist.
+if (!(await stat(join(REPOSITORY_ROOT, "plugins", "dsh", "package.json")).catch(() => undefined))) {
+  fail("plugins/dsh/package.json is missing, so DSH has no platform manifest");
+}
+
+for (const summary of notes) console.log(`ok: ${summary}`);
+if (problems.length > 0) {
+  console.error(`release check failed for ${releaseVersion}:`);
+  for (const problem of problems) console.error(`- ${problem}`);
+  process.exit(1);
+}
+console.log(`release check passed for ${releaseVersion} (${manifest.targets?.length ?? 0} host target(s))`);

--- a/tests/release_manifest.test.mjs
+++ b/tests/release_manifest.test.mjs
@@ -1,0 +1,105 @@
+// Proves the release check passes on the real tree and fails on each kind of drift.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, describe, it } from "node:test";
+
+const REPOSITORY_ROOT = fileURLToPath(new URL("../", import.meta.url));
+const roots = [];
+
+/** Copies the files the release check reads into a small tree it can be pointed at. */
+const releaseTree = async () => {
+  const root = await mkdtemp(join(tmpdir(), "distilly-release-"));
+  roots.push(root);
+  for (const path of ["scripts/check_release.mjs", "CHANGELOG.md", "plugins"]) {
+    await cp(join(REPOSITORY_ROOT, path), join(root, path), { recursive: true });
+  }
+  await cp(
+    join(REPOSITORY_ROOT, "packages/cli/src/evidence"),
+    join(root, "packages/cli/src/evidence"),
+    { recursive: true },
+  );
+  const packages = ["adapters", "bindings", "cli", "distilly", "engine", "mcp", "panel", "protocol", "runtime"];
+  for (const name of packages) {
+    await cp(join(REPOSITORY_ROOT, "packages", name, "package.json"), join(root, "packages", name, "package.json"), { recursive: true });
+  }
+  return root;
+};
+
+const runCheck = (root) =>
+  spawnSync(process.execPath, [join(root, "scripts", "check_release.mjs")], {
+    env: { ...process.env, DISTILLY_RELEASE_ROOT: root },
+    encoding: "utf8",
+  });
+
+after(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+describe("release consistency check", () => {
+  it("passes on an unmodified copy of the release tree", async () => {
+    const root = await releaseTree();
+    const result = runCheck(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /release check passed/u);
+  });
+
+  it("fails when a capacity fixture was measured for another release", async () => {
+    const root = await releaseTree();
+    const fixture = join(
+      root,
+      "packages/cli/src/evidence/host-capacity/codex-cli-0.146.0-cli-distilly-0.1.0-preview.1-v2.json",
+    );
+    const parsed = JSON.parse(await readFile(fixture, "utf8"));
+    parsed.releaseVersion = "0.0.0-previous";
+    await writeFile(fixture, `${JSON.stringify(parsed)}\n`);
+    const result = runCheck(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /was measured for release 0\.0\.0-previous/u);
+  });
+
+  it("fails when the canonical Skill tree no longer matches the manifest digest", async () => {
+    const root = await releaseTree();
+    const skill = join(root, "plugins/shared/skills/distilly/SKILL.md");
+    await writeFile(skill, `${await readFile(skill, "utf8")}\nchanged\n`);
+    const result = runCheck(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /canonicalSkill\.digest|canonical Skill file/u);
+  });
+
+  it("fails when a host target's plugin manifest version drifts", async () => {
+    const root = await releaseTree();
+    const manifest = join(root, "plugins/codex/.codex-plugin/plugin.json");
+    const parsed = JSON.parse(await readFile(manifest, "utf8"));
+    parsed.version = "9.9.9";
+    await writeFile(manifest, `${JSON.stringify(parsed, undefined, 2)}\n`);
+    const result = runCheck(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /declares version 9\.9\.9/u);
+  });
+
+  it("fails when the changelog has no section for the release", async () => {
+    const root = await releaseTree();
+    await writeFile(join(root, "CHANGELOG.md"), "# Changelog\n\nNothing here yet.\n");
+    const result = runCheck(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /CHANGELOG\.md has no section/u);
+  });
+
+  it("fails when a token budget is not derived from the measured bytes", async () => {
+    const root = await releaseTree();
+    const fixture = join(
+      root,
+      "packages/cli/src/evidence/host-capacity/codex-cli-0.146.0-cli-distilly-0.1.0-preview.1-v2.json",
+    );
+    const parsed = JSON.parse(await readFile(fixture, "utf8"));
+    parsed.capacity.estimatedInputTokens = parsed.capacity.verifiedBriefingBytes;
+    await writeFile(fixture, `${JSON.stringify(parsed)}\n`);
+    const result = runCheck(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /token budget that is not derived/u);
+  });
+});


### PR DESCRIPTION
## What
docs: verified host status; feat(release): one release tuple check

## Commits
- feat(release): verify one release tuple across every artifact that names it
- docs: describe the verified host status and the direct-user commands
- docs(cli): state what --limit counts and what import and rollback guarantee

## Stack
Stacked on `pr/10-dsh-home-and-legacy-import`; the whole series ends at `distilly-work` (`0bd924e`).

## Verification
Every feature carries an author report and an independent audit in the delivery evidence folder (`host-verification/`), including screenshots and the audit verdict that drove the fixes. Gates on the top of the stack: format, lint, docs, release check, and 1163 tests.

## Real hosts
Codex, Claude Code 2.1.268, OpenClaw 2026.9.2, Hermes v0.19.0, and DSH 0.1.5-rc.1 were each exercised end to end (install, host-visible confirmation, exactly five MCP tools, person Skill install/remove, uninstall). Capacity fixtures are recorded for Codex 0.146.0, OpenClaw 2026.3.24, and Hermes v0.9.0; newer host versions run on the labelled conservative floor.

## Evidence
Author reports and screenshots (delivery evidence folder `host-verification/`):
- f19-release-check-REPORT.md, f19-release-check.png

Independent audit reports:
- (release check is covered by tests/release_manifest.test.mjs; no separate audit)