### PR TITLE
fix: audit findings (persona registration, parsers, repair path, JSON output)

### DIFF
--- a/packages/adapters/src/chat-export-parser.test.ts
+++ b/packages/adapters/src/chat-export-parser.test.ts
@@ -157,8 +157,25 @@ describe("chat export detection", () => {
     expect(detectChatExport({ items: [{ id: 1 }] })).toBeUndefined();
     expect(detectChatExport([{ id: 1, name: "x" }])).toBeUndefined();
     expect(detectChatExport({ messages: [{ text: "no speaker" }] })).toBeUndefined();
+    // An application event log carries ts/user/text but is not a Slack conversation.
+    expect(
+      detectChatExport({
+        messages: [{ ts: "1714564800.5", user: "worker-1", text: "JOB_STARTED" }],
+      }),
+    ).toBeUndefined();
+    // An object with a mapping key is not a ChatGPT export without message nodes.
+    expect(detectChatExport([{ mapping: { a: 1 }, title: "de" }])).toBeUndefined();
     expect(detectChatExport("string")).toBeUndefined();
     expect(detectChatExport(undefined)).toBeUndefined();
+  });
+
+  it("recognizes an export whose dates are epoch numbers", () => {
+    expect(
+      detectChatExport({
+        name: "converted",
+        messages: [{ type: "message", from: "Ada", date: 1_772_000_000, text: "Ship it." }],
+      }),
+    ).toBe("telegram");
   });
 });
 
@@ -258,7 +275,22 @@ describe("json parser integration", () => {
 
   it("stores an export with no message text as unparsed with a warning", async () => {
     const parsed = await parser.parse(
-      raw([{ title: "empty", mapping: {}, current_node: "x" }]),
+      raw([
+        {
+          title: "empty",
+          current_node: "n1",
+          mapping: {
+            n1: {
+              id: "n1",
+              parent: null,
+              message: {
+                author: { role: "user" },
+                content: { content_type: "text", parts: [] },
+              },
+            },
+          },
+        },
+      ]),
       context,
     );
     expect(parsed.material).toBeUndefined();

--- a/packages/adapters/src/chat-export-parser.ts
+++ b/packages/adapters/src/chat-export-parser.ts
@@ -187,6 +187,7 @@ const readChatGpt = (
   if (!Array.isArray(value)) return { conversations, warnings };
   let skippedBranches = 0;
   let skippedMessages = 0;
+  let attachments = 0;
   for (const entry of value) {
     if (!isRecord(entry)) continue;
     const mapping = entry["mapping"];
@@ -208,6 +209,17 @@ const readChatGpt = (
       const content: unknown = message["content"];
       const read = isRecord(content) ? chatGptContent(content) : {};
       if (read.text === undefined) {
+        const parts = isRecord(content) ? asArray(content["parts"]) : undefined;
+        if (
+          parts?.some(
+            (part) =>
+              isRecord(part) &&
+              (asText(part["content_type"]) === "image_asset_pointer" ||
+                asText(part["content_type"]) === "audio_asset_pointer"),
+          ) === true
+        ) {
+          attachments += 1;
+        }
         skippedMessages += 1;
         continue;
       }
@@ -231,6 +243,9 @@ const readChatGpt = (
   if (skippedMessages > 0) {
     warnings.push(`${String(skippedMessages)} message(s) carried no text and were skipped.`);
   }
+  if (attachments > 0) {
+    warnings.push(`${String(attachments)} image or audio part(s) were not included as evidence.`);
+  }
   return { conversations, warnings };
 };
 
@@ -247,6 +262,7 @@ const readClaude = (
   const conversations: TranscriptConversation[] = [];
   if (!Array.isArray(value)) return { conversations, warnings };
   let skipped = 0;
+  let attachments = 0;
   for (const entry of value) {
     if (!isRecord(entry)) continue;
     const rawMessages = asArray(entry["chat_messages"]);
@@ -255,6 +271,8 @@ const readClaude = (
     for (const raw of rawMessages) {
       if (!isRecord(raw)) continue;
       const text = asText(raw["text"]);
+      attachments +=
+        (asArray(raw["attachments"])?.length ?? 0) + (asArray(raw["files"])?.length ?? 0);
       if (text === undefined) {
         skipped += 1;
         continue;
@@ -269,6 +287,9 @@ const readClaude = (
     conversations.push({ title, ...(at === undefined ? {} : { at }), messages });
   }
   if (skipped > 0) warnings.push(`${String(skipped)} message(s) carried no text and were skipped.`);
+  if (attachments > 0) {
+    warnings.push(`${String(attachments)} attachment(s) were not included as evidence.`);
+  }
   return { conversations, warnings };
 };
 
@@ -286,9 +307,11 @@ const readSlack = (
   if (rawMessages === undefined) return { conversations: [], warnings };
   const messages: TranscriptMessage[] = [];
   let skipped = 0;
+  let attachments = 0;
   for (const raw of rawMessages) {
     if (!isRecord(raw)) continue;
     const text = asText(raw["text"]);
+    attachments += asArray(raw["files"])?.length ?? 0;
     if (text === undefined) {
       skipped += 1;
       continue;
@@ -303,6 +326,9 @@ const readSlack = (
     });
   }
   if (skipped > 0) warnings.push(`${String(skipped)} message(s) carried no text and were skipped.`);
+  if (attachments > 0) {
+    warnings.push(`${String(attachments)} file(s) were not included as evidence.`);
+  }
   const channel = isRecord(value) ? asText(value["channel"]) : undefined;
   const channelName = isRecord(value) ? asText(value["name"]) : undefined;
   if (messages.length === 0) return { conversations: [], warnings };
@@ -383,12 +409,12 @@ const readDiscord = (
     const speaker = isRecord(author)
       ? (asText(author["nickname"]) ?? asText(author["name"]) ?? asText(author["id"]) ?? "unknown")
       : "unknown";
+    attachments += asArray(raw["attachments"])?.length ?? 0;
     const text = asText(raw["content"]);
     if (text === undefined) {
       skipped += 1;
       continue;
     }
-    attachments += asArray(raw["attachments"])?.length ?? 0;
     const at = normalizeInstant(raw["timestamp"]);
     messages.push({ speaker, ...(at === undefined ? {} : { at }), text });
   }
@@ -413,12 +439,14 @@ const readDiscord = (
 export const detectChatExport = (value: unknown): ChatExportKind | undefined => {
   const entries = Array.isArray(value) ? value : [];
   if (
-    entries.some(
-      (entry) =>
-        isRecord(entry) &&
-        isRecord(entry["mapping"]) &&
-        (asText(entry["current_node"]) !== undefined || asText(entry["title"]) !== undefined),
-    )
+    entries.some((entry) => {
+      if (!isRecord(entry) || !isRecord(entry["mapping"])) return false;
+      // A ChatGPT export stores conversation nodes whose `message` carries an author and
+      // content. Requiring one keeps a generic object with a `mapping` key out.
+      return Object.values(entry["mapping"]).some(
+        (node) => isRecord(node) && isRecord(node["message"]),
+      );
+    })
   ) {
     return "chatgpt";
   }
@@ -442,6 +470,9 @@ export const detectChatExport = (value: unknown): ChatExportKind | undefined => 
     messages.some(
       (message) =>
         isRecord(message) &&
+        // Real Slack messages declare their type; an event log with `ts`, `user`, and `text`
+        // does not, and treating one as a conversation would invent a person's words.
+        asText(message["type"]) === "message" &&
         asText(message["ts"]) !== undefined &&
         (asText(message["user"]) !== undefined ||
           asText(message["username"]) !== undefined ||
@@ -454,7 +485,8 @@ export const detectChatExport = (value: unknown): ChatExportKind | undefined => 
     messages.some(
       (message) =>
         isRecord(message) &&
-        asText(message["date"]) !== undefined &&
+        // Telegram writes an ISO date, but a converted export can carry epoch seconds.
+        (asText(message["date"]) !== undefined || typeof message["date"] === "number") &&
         (asText(message["from"]) !== undefined || asText(message["from_id"]) !== undefined),
     )
   ) {
@@ -494,6 +526,7 @@ export const renderChatExport = (
   let messageCount = 0;
   let conversationCount = 0;
   let truncated = 0;
+  let droppedParticipants = 0;
   for (const conversation of read.conversations) {
     if (bytes >= limits.maximumOutputBytes) {
       truncated += 1;
@@ -522,14 +555,20 @@ export const renderChatExport = (
       lines.push(rendered);
       bytes += renderedBytes;
       messageCount += 1;
-      if (!participants.includes(message.speaker) && participants.length < 32) {
-        participants.push(message.speaker);
+      if (!participants.includes(message.speaker)) {
+        if (participants.length < MAXIMUM_PARTICIPANTS) participants.push(message.speaker);
+        else droppedParticipants += 1;
       }
     }
   }
   if (truncated > 0) {
     warnings.push(
       `${String(truncated)} conversation(s) or message(s) were left out to stay within the output limit.`,
+    );
+  }
+  if (droppedParticipants > 0) {
+    warnings.push(
+      `${String(droppedParticipants)} further speaker(s) were not recorded because a material carries at most ${String(MAXIMUM_PARTICIPANTS)} participants.`,
     );
   }
   return {
@@ -541,6 +580,9 @@ export const renderChatExport = (
     warnings,
   };
 };
+
+/** Most participants one material may carry, matching the engine's own participant bound. */
+const MAXIMUM_PARTICIPANTS = 64;
 
 /** First line written for each recognized export. */
 const HEADERS: Readonly<Record<ChatExportKind, string>> = Object.freeze({

--- a/packages/bindings/src/claude-code/full.ts
+++ b/packages/bindings/src/claude-code/full.ts
@@ -59,6 +59,7 @@ export const createClaudeCodeHostBinding = (options: ClaudeCodeHostBindingOption
         transactionRoot: join(homeDirectory, ".distilly", "host-install"),
         platformManifestPath: PLATFORM_MANIFEST,
         expectedSkillDigest: options.release.canonicalSkillDigest,
+        repairDamaged: options.repairDamagedHost === true,
         mcpShape: (launcherPath) => ({
           mcpServers: {
             distilly: { command: launcherPath, args: ["mcp", "--host", host] },

--- a/packages/bindings/src/codex/full.ts
+++ b/packages/bindings/src/codex/full.ts
@@ -89,6 +89,7 @@ export const createCodexHostBinding = (options: CodexHostBindingOptions): HostBi
           transactionRoot: join(homeDirectory, ".distilly", "host-install"),
           platformManifestPath: PLATFORM_MANIFEST,
           expectedSkillDigest: options.release.canonicalSkillDigest,
+          repairDamaged: options.repairDamagedHost === true,
           mcpShape: (launcherPath) => ({
             mcpServers: {
               distilly: { command: launcherPath, args: ["mcp", "--host", host] },

--- a/packages/bindings/src/dsh-binding.test.ts
+++ b/packages/bindings/src/dsh-binding.test.ts
@@ -313,3 +313,29 @@ describe("DSH person Skill root", () => {
     void manifest;
   });
 });
+
+describe("DSH host-composed state", () => {
+  it("keeps the profile file DSH writes when Distilly installs again", async () => {
+    const home = await temporaryHome();
+    const manifest = JSON.parse(
+      await readFile(join(REPOSITORY_ROOT, "plugins", "release-manifest.json"), "utf8"),
+    ) as { releaseVersion: string };
+    const first = createDshHostBinding(await options(home));
+    const installed = await first.installPlugin({
+      launcherPath: await launcher(home),
+      pluginSourcePath: join(REPOSITORY_ROOT, "plugins", "dsh"),
+      runtimeVersion: manifest.releaseVersion,
+    });
+    const composed = join(installed.installedPaths[0]!, "cordis.yml");
+    // DSH composes this file when it boots the profile; a re-install must not delete it.
+    await writeFile(composed, "# composed by dsh\n");
+
+    const second = createDshHostBinding(await options(home));
+    await second.installPlugin({
+      launcherPath: await launcher(home),
+      pluginSourcePath: join(REPOSITORY_ROOT, "plugins", "dsh"),
+      runtimeVersion: manifest.releaseVersion,
+    });
+    expect(await readFile(composed, "utf8")).toBe("# composed by dsh\n");
+  });
+});

--- a/packages/bindings/src/dsh/full.ts
+++ b/packages/bindings/src/dsh/full.ts
@@ -304,6 +304,7 @@ export const createDshHostBinding = (options: DshHostBindingOptions): HostBindin
           transactionRoot: join(homeDirectory, ".distilly", "host-install"),
           platformManifestPath: PROFILE_MANIFEST,
           expectedSkillDigest: options.release.canonicalSkillDigest,
+          repairDamaged: options.repairDamagedHost === true,
           mcpShape: () => ({}),
           preservePlatformManifestFields: true,
           // DSH composes the profile and writes its own cordis.yml beside the layer we own.

--- a/packages/bindings/src/full-binding.test.ts
+++ b/packages/bindings/src/full-binding.test.ts
@@ -732,3 +732,52 @@ describe("person Skill lifecycle", () => {
     expect(await readFile(join(first.path, "SKILL.md"), "utf8")).toBe("hand edited\n");
   });
 });
+
+describe("Claude Code person Skill registration", () => {
+  it("writes the plugin marker Claude Code needs and removes it again", async () => {
+    const home = await temporaryHome();
+    const binding = createClaudeCodeHostBinding(sharedOptions(home));
+    const injector = binding.createInjector({ sessionId: "claude-marker", environment: "cli" });
+    const installed = await injector.install(PROFILE, {});
+    const marker = join(installed.path, ".claude-plugin", "plugin.json");
+    const originalMarker = await readFile(marker);
+    const parsed = JSON.parse(originalMarker.toString("utf8")) as {
+      name: string;
+      version: string;
+      skills: string[];
+      description: string;
+    };
+    expect(parsed.name).toBe(basename(installed.path));
+    expect(parsed.version).toBe(`0.0.0-${VERSION_ID.replace(/^version_/u, "").slice(0, 12)}`);
+    expect(parsed.skills).toEqual(["./"]);
+    expect(parsed.description).toContain("Ada Lovelace");
+
+    const manifest = JSON.parse(
+      await readFile(join(installed.path, ".distilly-install.json"), "utf8"),
+    ) as { files: { path: string }[] };
+    expect(manifest.files.map((file) => file.path).sort()).toEqual([
+      ".claude-plugin/plugin.json",
+      "SKILL.md",
+    ]);
+
+    // A tampered marker is a modified install, exactly like a tampered SKILL.md.
+    await writeFile(marker, "{}\n");
+    await expect(injector.uninstall(installed)).rejects.toMatchObject({ code: "storage_corrupt" });
+
+    await writeFile(marker, originalMarker);
+    await injector.uninstall(installed);
+    await expect(readFile(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readdir(join(home, ".claude", "skills"))).toEqual([]);
+  });
+
+  it("keeps other hosts free of the Claude Code marker", async () => {
+    const home = await temporaryHome();
+    const binding = createCodexHostBinding({
+      ...sharedOptions(home),
+      executablePath: "/usr/bin/codex",
+    });
+    const injector = binding.createInjector({ sessionId: "codex-marker", environment: "cli" });
+    const installed = await injector.install(PROFILE, {});
+    expect(await readdir(installed.path)).toEqual([".distilly-install.json", "SKILL.md"]);
+  });
+});

--- a/packages/bindings/src/full-binding.test.ts
+++ b/packages/bindings/src/full-binding.test.ts
@@ -781,3 +781,58 @@ describe("Claude Code person Skill registration", () => {
     expect(await readdir(installed.path)).toEqual([".distilly-install.json", "SKILL.md"]);
   });
 });
+
+describe("damaged install repair", () => {
+  it("refuses a damaged tree by default and repairs it only when asked", async () => {
+    const home = await temporaryHome();
+    const manifest = JSON.parse(
+      await readFile(join(REPOSITORY_ROOT, "plugins", "release-manifest.json"), "utf8"),
+    ) as { releaseVersion: string };
+    const install = async (options: FullHostBindingOptions) => {
+      const binding = createClaudeCodeHostBinding(options);
+      return await binding.installPlugin({
+        launcherPath: join(home, ".distilly", "bin", "distilly"),
+        pluginSourcePath: join(REPOSITORY_ROOT, "plugins", "claude-code"),
+        runtimeVersion: manifest.releaseVersion,
+      });
+    };
+    const installed = await install(sharedOptions(home));
+    const ownedFile = join(installed.installedPaths[0]!, "skills", "distilly", "SKILL.md");
+    await rm(ownedFile);
+
+    await expect(install(sharedOptions(home))).rejects.toMatchObject({ code: "storage_corrupt" });
+
+    const repaired = await install({ ...sharedOptions(home), repairDamagedHost: true });
+    expect(repaired.repairBackupPath).toBeDefined();
+    // The damaged tree is preserved rather than deleted, so nothing the operator had is lost.
+    expect(
+      await readFile(join(repaired.repairBackupPath!, "skills", "distilly", "SKILL.md")).catch(
+        () => undefined,
+      ),
+    ).toBeUndefined();
+    expect(await readdir(repaired.repairBackupPath!)).toContain("skills");
+    expect(await readFile(ownedFile, "utf8")).toContain("Distilly");
+  });
+
+  it("never claims a directory that has no Distilly ownership manifest", async () => {
+    const home = await temporaryHome();
+    const manifest = JSON.parse(
+      await readFile(join(REPOSITORY_ROOT, "plugins", "release-manifest.json"), "utf8"),
+    ) as { releaseVersion: string };
+    const pluginRoot = join(home, ".claude", "skills", "distilly");
+    await mkdir(pluginRoot, { recursive: true });
+    await writeFile(join(pluginRoot, "foreign.txt"), "someone else's skill\n");
+    const binding = createClaudeCodeHostBinding({
+      ...sharedOptions(home),
+      repairDamagedHost: true,
+    });
+    await expect(
+      binding.installPlugin({
+        launcherPath: join(home, ".distilly", "bin", "distilly"),
+        pluginSourcePath: join(REPOSITORY_ROOT, "plugins", "claude-code"),
+        runtimeVersion: manifest.releaseVersion,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_input" });
+    expect(await readFile(join(pluginRoot, "foreign.txt"), "utf8")).toBe("someone else's skill\n");
+  });
+});

--- a/packages/bindings/src/full/injector.ts
+++ b/packages/bindings/src/full/injector.ts
@@ -31,12 +31,58 @@ import type { HostInjector, HostSpawnRequest, Injection } from "../protocol.js";
 
 const INSTALL_MANIFEST = ".distilly-install.json";
 const SKILL_FILE = "SKILL.md";
+/**
+ * Registration marker Claude Code needs before it adopts a skills-directory plugin.
+ *
+ * The host's own `claude plugin init` writes exactly this file beside `SKILL.md`; a bare
+ * `SKILL.md` directory is not registered (verified against the real binary), so a person Skill
+ * installed for Claude Code carries one too. The version is the profile's immutable version
+ * prefix, which keeps every install a distinct valid prerelease without inventing a release.
+ */
+const CLAUDE_CODE_PLUGIN_FILE = ".claude-plugin/plugin.json";
 
 interface PersonInstallManifest {
   readonly schemaVersion: 1;
   readonly install: InstallRef;
-  readonly files: readonly [{ readonly path: "SKILL.md"; readonly contentDigest: ContentDigest }];
+  /** Every file this install owns, verified byte for byte; SKILL.md is always present. */
+  readonly files: readonly {
+    readonly path: string;
+    readonly contentDigest: ContentDigest;
+  }[];
 }
+
+/** Paths an owned person Skill may contain besides SKILL.md. */
+const ALLOWED_PERSON_FILES: ReadonlySet<string> = new Set([CLAUDE_CODE_PLUGIN_FILE]);
+
+/**
+ * Builds the host registration marker for one person Skill, when the host needs one.
+ *
+ * @param host - Host the Skill is installed for.
+ * @param name - Skill directory name the host will register.
+ * @param profile - Profile being installed.
+ * @returns The file to write, or undefined when this host registers a bare SKILL.md.
+ */
+const personRegistrationFile = (
+  host: HostName,
+  name: string,
+  profile: Profile,
+): { readonly path: string; readonly bytes: Uint8Array } | undefined => {
+  if (host !== "claude-code") return undefined;
+  const version = profile.versionId.replace(/^version_/u, "").slice(0, 12);
+  return {
+    path: CLAUDE_CODE_PLUGIN_FILE,
+    bytes: Buffer.from(
+      `${canonicalJson({
+        $schema: "https://anthropic.com/claude-code/plugin.schema.json",
+        name,
+        version: `0.0.0-${version}`,
+        description: `Use ${profile.displayName}'s evidence-grounded Distilly Person Profile when the user explicitly selects it.`,
+        skills: ["./"],
+      })}\n`,
+      "utf8",
+    ),
+  };
+};
 
 const invalid = (message: string, fieldPath?: string): DistillyError =>
   new DistillyError({
@@ -176,30 +222,47 @@ const parseManifest = (bytes: Uint8Array): PersonInstallManifest => {
   if (value === null || typeof value !== "object" || Array.isArray(value)) throw modified();
   const manifest = value as Record<string, unknown>;
   const parsedInstall = installRefSchema.safeParse(manifest.install);
-  const files = manifest.files;
-  const file: unknown = Array.isArray(files) ? (files as unknown[])[0] : undefined;
+  const rawFiles = manifest.files;
   if (
     !hasExactKeys(manifest, ["schemaVersion", "install", "files"]) ||
     manifest.schemaVersion !== 1 ||
     !parsedInstall.success ||
-    !Array.isArray(files) ||
-    files.length !== 1 ||
-    file === null ||
-    typeof file !== "object" ||
-    Array.isArray(file) ||
-    !hasExactKeys(file as Record<string, unknown>, ["path", "contentDigest"]) ||
-    (file as Record<string, unknown>).path !== SKILL_FILE ||
-    !contentDigestSchema.safeParse((file as Record<string, unknown>).contentDigest).success
+    !Array.isArray(rawFiles) ||
+    rawFiles.length === 0
   ) {
     throw modified();
   }
-  const contentDigest = (file as { contentDigest: ContentDigest }).contentDigest;
-  if (parsedInstall.data.contentDigest !== contentDigest) throw modified();
-  return {
-    schemaVersion: 1,
-    install: parsedInstall.data,
-    files: [{ path: SKILL_FILE, contentDigest }],
-  };
+  const files: { path: string; contentDigest: ContentDigest }[] = [];
+  const paths = new Set<string>();
+  for (const entry of rawFiles) {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      Array.isArray(entry) ||
+      !hasExactKeys(entry as Record<string, unknown>, ["path", "contentDigest"])
+    ) {
+      throw modified();
+    }
+    const path = (entry as { path: unknown }).path;
+    if (
+      typeof path !== "string" ||
+      (path !== SKILL_FILE && !ALLOWED_PERSON_FILES.has(path)) ||
+      paths.has(path) ||
+      !contentDigestSchema.safeParse((entry as { contentDigest: unknown }).contentDigest).success
+    ) {
+      throw modified();
+    }
+    paths.add(path);
+    files.push({
+      path,
+      contentDigest: (entry as { contentDigest: ContentDigest }).contentDigest,
+    });
+  }
+  const skill = files.find((file) => file.path === SKILL_FILE);
+  if (skill === undefined || parsedInstall.data.contentDigest !== skill.contentDigest) {
+    throw modified();
+  }
+  return { schemaVersion: 1, install: parsedInstall.data, files };
 };
 
 const readRegularFile = async (path: string): Promise<Uint8Array> => {
@@ -242,7 +305,11 @@ const readVerifiedInstall = async (
   ) {
     throw modified();
   }
-  if (digest(await readRegularFile(skillPath)) !== install.contentDigest) throw modified();
+  for (const file of manifest.files) {
+    const path = resolve(root, file.path);
+    if (!isInside(root, path)) throw modified();
+    if (digest(await readRegularFile(path)) !== file.contentDigest) throw modified();
+  }
   return manifest;
 };
 
@@ -296,11 +363,29 @@ const installProfile = async (
       path: destination,
       installedAt: isoDateTimeSchema.parse(now().toISOString()),
     };
-    await replaceInstall(destination, homeDirectory, host, skill, {
-      schemaVersion: 1,
-      install: replaced,
-      files: [{ path: SKILL_FILE, contentDigest }],
-    });
+    const replacementRegistration = personRegistrationFile(host, name, profile);
+    await replaceInstall(
+      destination,
+      homeDirectory,
+      host,
+      skill,
+      {
+        schemaVersion: 1,
+        install: replaced,
+        files: [
+          { path: SKILL_FILE, contentDigest },
+          ...(replacementRegistration === undefined
+            ? []
+            : [
+                {
+                  path: replacementRegistration.path,
+                  contentDigest: digest(replacementRegistration.bytes),
+                },
+              ]),
+        ],
+      },
+      replacementRegistration,
+    );
     return replaced;
   }
 
@@ -309,10 +394,16 @@ const installProfile = async (
     ...identity,
     installedAt: isoDateTimeSchema.parse(now().toISOString()),
   };
+  const registration = personRegistrationFile(host, name, profile);
   const manifest: PersonInstallManifest = {
     schemaVersion: 1,
     install,
-    files: [{ path: SKILL_FILE, contentDigest }],
+    files: [
+      { path: SKILL_FILE, contentDigest },
+      ...(registration === undefined
+        ? []
+        : [{ path: registration.path, contentDigest: digest(registration.bytes) }]),
+    ],
   };
 
   await mkdir(dirname(root), { recursive: true });
@@ -322,6 +413,10 @@ const installProfile = async (
   try {
     await mkdir(staging);
     await writeFile(join(staging, SKILL_FILE), skill, { mode: 0o644 });
+    if (registration !== undefined) {
+      await mkdir(dirname(join(staging, registration.path)), { recursive: true });
+      await writeFile(join(staging, registration.path), registration.bytes, { mode: 0o644 });
+    }
     await writeFile(join(staging, INSTALL_MANIFEST), `${canonicalJson(manifest)}\n`, {
       mode: 0o600,
     });
@@ -345,6 +440,9 @@ const installProfile = async (
  * @param host - Host the Skill belongs to.
  * @param skill - New SKILL.md content.
  * @param manifest - New install manifest.
+ * @param registration - Host registration marker to write beside SKILL.md, when the host needs one.
+ * @param registration.path - Root-relative path of the marker.
+ * @param registration.bytes - Exact marker bytes.
  */
 const replaceInstall = async (
   destination: string,
@@ -352,6 +450,7 @@ const replaceInstall = async (
   host: HostName,
   skill: string,
   manifest: PersonInstallManifest,
+  registration?: { readonly path: string; readonly bytes: Uint8Array },
 ): Promise<void> => {
   const transactionRoot = join(homeDirectory, ".distilly", "host-install");
   await mkdir(transactionRoot, { recursive: true });
@@ -359,6 +458,10 @@ const replaceInstall = async (
   const backup = join(transactionRoot, `${host}-person-previous-${randomUUID()}`);
   await mkdir(staging);
   await writeFile(join(staging, SKILL_FILE), skill, { mode: 0o644 });
+  if (registration !== undefined) {
+    await mkdir(dirname(join(staging, registration.path)), { recursive: true });
+    await writeFile(join(staging, registration.path), registration.bytes, { mode: 0o644 });
+  }
   await writeFile(join(staging, INSTALL_MANIFEST), `${canonicalJson(manifest)}\n`, { mode: 0o600 });
   let movedAside = false;
   try {
@@ -425,6 +528,9 @@ export const listPersonInstalls = async (
   const summaries: PersonInstallSummary[] = [];
   for (const entry of entries) {
     if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    // Claude Code keeps the Distilly integration Skill itself in the same skills root. It is
+    // not a person Skill, so listing it as an unverifiable one would only confuse the report.
+    if (entry.name === "distilly") continue;
     const path = join(root, entry.name);
     try {
       const manifest = await readVerifiedInstall(path, host);
@@ -466,9 +572,27 @@ const uninstallProfile = async (host: HostName, ref: InstallRef): Promise<void> 
   if (existing === undefined) return;
   const manifest = await readVerifiedInstall(root, host);
   if (canonicalJson(manifest.install) !== canonicalJson(parsedRef.data)) throw modified();
-  const skillPath = resolve(root, SKILL_FILE);
-  await unlink(skillPath);
+  for (const file of manifest.files) {
+    const path = resolve(root, file.path);
+    if (!isInside(root, path)) throw modified();
+    await unlink(path);
+  }
   await unlink(join(root, INSTALL_MANIFEST));
+  // A registration marker sits in its own directory, so clear the directories it leaves behind.
+  const directories = new Set<string>();
+  for (const file of manifest.files) {
+    let directory = dirname(resolve(root, file.path));
+    while (isInside(root, directory) && directory !== root) {
+      directories.add(directory);
+      directory = dirname(directory);
+    }
+  }
+  for (const directory of [...directories].sort((left, right) => right.length - left.length)) {
+    await rmdir(directory).catch((error: unknown) => {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOTEMPTY" && code !== "ENOENT") throw error;
+    });
+  }
   await rmdir(root).catch((error: unknown) => {
     if ((error as NodeJS.ErrnoException).code !== "ENOTEMPTY") throw error;
   });

--- a/packages/bindings/src/full/injector.ts
+++ b/packages/bindings/src/full/injector.ts
@@ -171,6 +171,9 @@ const renderPersonSkill = (profile: Profile, name: string): string => {
   );
 };
 
+export const personSkillsRoot = (host: HostName, homeDirectory: string): string =>
+  defaultSkillsRoot(host, homeDirectory);
+
 const defaultSkillsRoot = (host: HostName, homeDirectory: string): string => {
   if (host === "codex") return join(homeDirectory, ".codex", "skills");
   if (host === "claude-code") return join(homeDirectory, ".claude", "skills");

--- a/packages/bindings/src/full/plugin-tree.ts
+++ b/packages/bindings/src/full/plugin-tree.ts
@@ -46,6 +46,13 @@ interface PluginOwnershipManifest {
    * list still fails as an unowned file.
    */
   readonly hostGeneratedPaths?: readonly string[];
+  /**
+   * Moves a damaged Distilly tree aside and installs fresh instead of failing closed.
+   *
+   * Only a directory that carries Distilly's ownership manifest is moved, and it is preserved
+   * under a timestamped sibling name, so the operator can inspect or restore it.
+   */
+  readonly repairDamaged?: boolean;
 }
 
 interface PreparedPlugin {
@@ -85,6 +92,13 @@ export interface PluginTreeOptions {
    * host is known to write, and removal deletes them with the tree it owns.
    */
   readonly hostGeneratedPaths?: readonly string[];
+  /**
+   * Moves a damaged Distilly tree aside and installs fresh instead of failing closed.
+   *
+   * Only a directory that carries Distilly's ownership manifest is moved, and it is preserved
+   * under a timestamped sibling name, so the operator can inspect or restore it.
+   */
+  readonly repairDamaged?: boolean;
 }
 
 const fail = (message: string, fieldPath?: string): DistillyError =>
@@ -498,6 +512,7 @@ export const installPluginTree = async (
   const backup = join(options.transactionRoot, `${options.host}-${transactionId}-backup`);
   let installed = false;
   let backedUp = false;
+  let repairBackupPath: string | undefined;
   try {
     await mkdir(staging, { recursive: false });
     for (const [path, bytes] of prepared.files) {
@@ -510,9 +525,30 @@ export const installPluginTree = async (
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
       throw error;
     });
-    const existingOwnership = await readVerifiedPluginTree(options.pluginRoot, options.host);
+    let existingOwnership: PluginOwnershipManifest | undefined;
+    let verificationFailed = false;
+    try {
+      existingOwnership = await readVerifiedPluginTree(options.pluginRoot, options.host);
+    } catch (error) {
+      // A damaged tree throws instead of returning undefined; that is exactly the state an
+      // explicit repair is meant to recover from, so the failure is remembered, not rethrown.
+      verificationFailed = true;
+      if (options.repairDamaged !== true) throw error;
+    }
     if (existingMetadata !== undefined && existingOwnership === undefined) {
-      throw fail("The host plugin destination is not owned by Distilly.");
+      // A damaged install used to be a dead end: doctor, uninstall, and setup all refused it.
+      // An explicit repair moves it aside, but only when Distilly's own manifest proves it is
+      // ours; anything else is left exactly where it is.
+      const damaged =
+        options.repairDamaged === true &&
+        verificationFailed &&
+        (await hasOwnershipManifest(options.pluginRoot));
+      if (!damaged) throw fail("The host plugin destination is not owned by Distilly.");
+      repairBackupPath = join(options.transactionRoot, `${options.host}-repaired-${transactionId}`);
+      await mkdir(options.transactionRoot, { recursive: true });
+      await rename(options.pluginRoot, repairBackupPath);
+      existingOwnership = undefined;
+      backedUp = false;
     }
     if (existingOwnership !== undefined) {
       await rename(options.pluginRoot, backup);
@@ -537,6 +573,9 @@ export const installPluginTree = async (
     }
   } catch (error) {
     if (installed) await rm(options.pluginRoot, { recursive: true, force: true });
+    if (repairBackupPath !== undefined) {
+      await rename(repairBackupPath, options.pluginRoot).catch(() => undefined);
+    }
     if (backedUp) await rename(backup, options.pluginRoot);
     await rm(staging, { recursive: true, force: true });
     throw error;
@@ -544,6 +583,7 @@ export const installPluginTree = async (
   return {
     host: options.host,
     manifestPath: join(options.pluginRoot, options.platformManifestPath),
+    ...(repairBackupPath === undefined ? {} : { repairBackupPath }),
     installedPaths: [
       options.pluginRoot,
       join(options.pluginRoot, INSTALLED_MCP_FILE),
@@ -551,6 +591,24 @@ export const installPluginTree = async (
     ],
     restartRequired: true,
   };
+};
+
+/**
+ * Reports whether a directory carries a Distilly ownership manifest, valid or not.
+ *
+ * A repair is allowed for a directory Distilly wrote and that later lost or changed files; it
+ * is never allowed for a directory that has no manifest at all.
+ *
+ * @param pluginRoot - Candidate host plugin directory.
+ * @returns True when the ownership manifest exists as a regular file.
+ */
+const hasOwnershipManifest = async (pluginRoot: string): Promise<boolean> => {
+  try {
+    const metadata = await lstat(join(pluginRoot, OWNERSHIP_FILE));
+    return metadata.isFile() && !metadata.isSymbolicLink();
+  } catch {
+    return false;
+  }
 };
 
 const launcherReachable = async (path: string): Promise<boolean> => {

--- a/packages/bindings/src/full/plugin-tree.ts
+++ b/packages/bindings/src/full/plugin-tree.ts
@@ -521,7 +521,20 @@ export const installPluginTree = async (
     await rename(staging, options.pluginRoot);
     installed = true;
     await activate?.();
-    if (backedUp) await rm(backup, { recursive: true, force: true });
+    if (backedUp) {
+      // A host that composes state inside its plugin root (DSH writes cordis.yml) keeps that
+      // state across a re-install: copying it back avoids deleting the host's own file.
+      for (const path of existingOwnership?.hostGeneratedPaths ?? []) {
+        const source = join(backup, path);
+        const bytes = await readFile(source).catch(() => undefined);
+        if (bytes === undefined) continue;
+        const destination = join(options.pluginRoot, path);
+        if (!isInside(options.pluginRoot, destination)) continue;
+        await mkdir(dirname(destination), { recursive: true });
+        await writeFile(destination, bytes, { mode: 0o644 });
+      }
+      await rm(backup, { recursive: true, force: true });
+    }
   } catch (error) {
     if (installed) await rm(options.pluginRoot, { recursive: true, force: true });
     if (backedUp) await rename(backup, options.pluginRoot);

--- a/packages/bindings/src/index.ts
+++ b/packages/bindings/src/index.ts
@@ -8,7 +8,7 @@ export { createHermesCapabilityBinding } from "./hermes/capability.js";
 export { createHermesHostBinding } from "./hermes/full.js";
 export { createOpenClawCapabilityBinding } from "./openclaw/capability.js";
 export { createOpenClawHostBinding } from "./openclaw/full.js";
-export { listPersonInstalls } from "./full/injector.js";
+export { listPersonInstalls, personSkillsRoot } from "./full/injector.js";
 export { HostRegistry } from "./registry.js";
 export type { PersonInstallSummary } from "./full/injector.js";
 export type {

--- a/packages/bindings/src/openclaw/full.ts
+++ b/packages/bindings/src/openclaw/full.ts
@@ -322,6 +322,7 @@ export const createOpenClawHostBinding = (options: OpenClawHostBindingOptions): 
           transactionRoot: join(homeDirectory, ".distilly", "host-install"),
           platformManifestPath: PLATFORM_MANIFEST,
           expectedSkillDigest: options.release.canonicalSkillDigest,
+          repairDamaged: options.repairDamagedHost === true,
           mcpShape: (launcherPath) => ({
             mcpServers: {
               distilly: { command: launcherPath, args: ["mcp", "--host", host] },

--- a/packages/bindings/src/protocol.ts
+++ b/packages/bindings/src/protocol.ts
@@ -61,6 +61,8 @@ export interface PluginInstallResult {
   readonly manifestPath: string;
   readonly installedPaths: readonly string[];
   readonly restartRequired: boolean;
+  /** Where a repaired damaged tree was preserved, when the operator asked for a repair. */
+  readonly repairBackupPath?: string;
 }
 
 /** Sanitized health report from a production host binding. */
@@ -144,6 +146,14 @@ export interface FullHostBindingOptions extends HostCapabilityBindingOptions {
   readonly homeDirectory: string;
   readonly forms: HostFormPresenter;
   readonly now?: () => Date;
+  /**
+   * Rebuilds a damaged Distilly plugin tree after moving it aside.
+   *
+   * The operator asks for this explicitly, and only a directory that carries Distilly's own
+   * ownership manifest is moved: the previous tree is preserved under a timestamped name, so
+   * a repair never deletes anything it cannot prove it wrote.
+   */
+  readonly repairDamagedHost?: boolean;
 }
 
 /** Codex full-binding inputs, including the checked host executable. */

--- a/packages/cli/src/harvest.ts
+++ b/packages/cli/src/harvest.ts
@@ -48,6 +48,8 @@ export interface HarvestSelection {
     readonly relativePath: string;
     readonly reason: HarvestSkipReason;
   }[];
+  /** True when more paths were skipped than `skippedEntries` could keep. */
+  readonly skippedEntriesTruncated: boolean;
   readonly directoriesVisited: number;
   /** True when the selection cap stopped the walk before every entry was considered. */
   readonly truncated: boolean;
@@ -143,6 +145,7 @@ export const selectHarvestFiles = async (
   const maximumFiles = options.maximumFiles ?? DEFAULT_MAXIMUM_FILES;
   const skipped: Partial<Record<HarvestSkipReason, number>> = {};
   const skippedEntries: { relativePath: string; reason: HarvestSkipReason }[] = [];
+  let skippedEntriesTruncated = false;
   const files: HarvestFile[] = [];
   const labels = new Set<string>();
   let directoriesVisited = 0;
@@ -150,8 +153,11 @@ export const selectHarvestFiles = async (
 
   const skip = (reason: HarvestSkipReason, relativePath?: string): void => {
     skipped[reason] = (skipped[reason] ?? 0) + 1;
-    if (relativePath !== undefined && skippedEntries.length < MAXIMUM_SKIP_DETAILS) {
+    if (relativePath === undefined) return;
+    if (skippedEntries.length < MAXIMUM_SKIP_DETAILS) {
       skippedEntries.push({ relativePath, reason });
+    } else {
+      skippedEntriesTruncated = true;
     }
   };
 
@@ -218,25 +224,37 @@ export const selectHarvestFiles = async (
   // The walk already emits entries in order, but a directory boundary can interleave a
   // deeper path before a sibling file, so the final order is fixed explicitly.
   files.sort((left, right) => compareUtf8(left.relativePath, right.relativePath));
-  return { files, skipped, skippedEntries, directoriesVisited, truncated };
+  return {
+    files,
+    skipped,
+    skippedEntries,
+    skippedEntriesTruncated,
+    directoriesVisited,
+    truncated,
+  };
 };
 
 /**
  * Renders the individual files a selection left out, so lost evidence is visible by name.
  *
  * @param selection - Result of one directory selection.
- * @param limit - Largest number of entries to render.
+ * @param limit - Largest number of entries to render; defaults to every collected entry.
  * @returns One line per skipped path, plus a count when more were left out.
  */
 export const describeSkippedEntries = (
   selection: HarvestSelection,
-  limit = 20,
+  limit = selection.skippedEntries.length,
 ): readonly string[] => {
   const lines = selection.skippedEntries
     .slice(0, limit)
     .map((entry) => `  skipped ${entry.relativePath}: ${entry.reason}`);
   const remaining = selection.skippedEntries.length - lines.length;
   if (remaining > 0) lines.push(`  ... and ${String(remaining)} more skipped entry(ies).`);
+  if (selection.skippedEntriesTruncated) {
+    lines.push(
+      `  ... and more than ${String(selection.skippedEntries.length)} skipped entries in total; only the first were listed.`,
+    );
+  }
   return lines;
 };
 

--- a/packages/cli/src/legacy-import.ts
+++ b/packages/cli/src/legacy-import.ts
@@ -63,13 +63,28 @@ export const isLegacyPersonDirectory = async (directory: string): Promise<boolea
   if ((await hasFile("persona.md")) || (await hasFile("work.md"))) return true;
   if (!(await hasFile("meta.json"))) return false;
   // A directory that holds only a descriptor but also contains person directories is a
-  // category, not a person: treating it as a person would swallow everyone below it.
+  // category, not a person: treating it as a person would swallow everyone below it. The search
+  // has to match the walker's depth, or an intermediate folder hides the people under it.
+  return !(await containsPersonDirectory(directory, 1));
+};
+
+/**
+ * Reports whether any person directory exists below one directory, within the search depth.
+ *
+ * @param directory - Directory to search.
+ * @param depth - Current depth below the original path.
+ * @returns True when a person directory was found.
+ */
+const containsPersonDirectory = async (directory: string, depth: number): Promise<boolean> => {
+  if (depth > LEGACY_SEARCH_DEPTH) return false;
   const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
   for (const entry of entries) {
     if (!entry.isDirectory() || entry.isSymbolicLink() || entry.name.startsWith(".")) continue;
-    if (await isLegacyPersonDirectory(join(directory, entry.name))) return false;
+    const child = join(directory, entry.name);
+    if (await isLegacyPersonDirectory(child)) return true;
+    if (await containsPersonDirectory(child, depth + 1)) return true;
   }
-  return true;
+  return false;
 };
 
 /**

--- a/packages/cli/src/lifecycle.ts
+++ b/packages/cli/src/lifecycle.ts
@@ -141,6 +141,8 @@ export interface PreviewSetupResult {
   readonly launcherPath: string;
   readonly releaseVersion: string;
   readonly restartRequired: true;
+  /** Where the damaged tree was preserved when the operator asked for a repair. */
+  readonly repairBackupPath?: string;
 }
 
 /** Narrow lifecycle plus binding health; it deliberately excludes deep Engine doctor. */
@@ -686,8 +688,10 @@ const createBinding = (
   release: ReleaseManifest,
   executablePath: string,
   allowUnverifiedHost = false,
+  repairDamagedHost = false,
 ): HostBinding => {
   const options = {
+    ...(repairDamagedHost ? { repairDamagedHost: true } : {}),
     homeDirectory:
       host === BUILTIN_HOSTS.dsh
         ? (environment.dshHomeDirectory ?? environment.homeDirectory)
@@ -813,12 +817,14 @@ const assertEnvironment = (environment: PreviewLifecycleEnvironment): void => {
  * @param options - Install policy.
  * @param options.allowUnverifiedHost - Accepts an unrecorded host version on the
  * conservative floor instead of failing closed.
+ * @param options.repairDamagedHost - Moves a damaged Distilly plugin tree aside and installs
+ * fresh, preserving the previous tree for inspection.
  * @returns The installed host and restart requirement.
  */
 export const setupPreviewHost = async (
   hostValue: HostName,
   environment: PreviewLifecycleEnvironment,
-  options: { readonly allowUnverifiedHost?: boolean } = {},
+  options: { readonly allowUnverifiedHost?: boolean; readonly repairDamagedHost?: boolean } = {},
 ): Promise<PreviewSetupResult> => {
   assertEnvironment(environment);
   const host = previewHost(hostValue);
@@ -869,6 +875,7 @@ export const setupPreviewHost = async (
     release,
     executablePath,
     options.allowUnverifiedHost === true,
+    options.repairDamagedHost === true,
   );
   const preflight = await binding.preflight({ sessionId: `setup-${host}`, environment: "cli" });
   if (!preflight.ok) {
@@ -1006,6 +1013,9 @@ export const setupPreviewHost = async (
       launcherPath: paths.launcher,
       releaseVersion: release.releaseVersion,
       restartRequired: true,
+      ...(installed.repairBackupPath === undefined
+        ? {}
+        : { repairBackupPath: installed.repairBackupPath }),
     };
   } catch (error) {
     // Restore the manifest this attempt replaced, so a failed projection leaves no entry

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -342,3 +342,14 @@ describe("Developer Preview CLI host boundary", () => {
     expect(stdout).toEqual([]);
   });
 });
+
+describe("person Skill listing root", () => {
+  it("names the real skills root even when nothing is installed", async () => {
+    const { personSkillsRoot } = await import("@distilly/bindings");
+    expect(personSkillsRoot("codex" as never, "/home/u")).toBe("/home/u/.codex/skills");
+    expect(personSkillsRoot("claude-code" as never, "/home/u")).toBe("/home/u/.claude/skills");
+    expect(personSkillsRoot("openclaw" as never, "/home/u")).toBe("/home/u/.openclaw/skills");
+    expect(personSkillsRoot("hermes" as never, "/home/u")).toBe("/home/u/.hermes/skills");
+    expect(personSkillsRoot("dsh" as never, "/dsh")).toBe("/dsh/skills");
+  });
+});

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -250,6 +250,30 @@ describe("Developer Preview CLI host boundary", () => {
     ).rejects.toThrow("The import path must be an existing directory.");
   });
 
+  it("accepts an explicit repair flag and rejects unknown setup flags", async () => {
+    const io = {
+      stdout: { write: (value: string) => value },
+      stderr: { write: (value: string) => value },
+    };
+    await expect(
+      runPreviewCli(["setup", "--repair", "--host", "codex"], environment, io),
+    ).rejects.toThrow();
+    await expect(
+      runPreviewCli(["setup", "--host", "codex", "--nope"], environment, io),
+    ).rejects.toThrow();
+  });
+
+  it("documents the repair flag", async () => {
+    const stdout: string[] = [];
+    await expect(
+      runPreviewCli(["--help"], environment, {
+        stdout: { write: (value: string) => stdout.push(value) },
+        stderr: { write: (value: string) => value },
+      }),
+    ).resolves.toBe(0);
+    expect(stdout.join("")).toContain("[--repair]");
+  });
+
   it("documents the legacy import command", async () => {
     const stdout: string[] = [];
     await expect(

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -11,7 +11,11 @@ import {
   type HostName,
   type SubjectSummary,
 } from "@distilly/protocol";
-import { listPersonInstalls, type PersonInstallSummary } from "@distilly/bindings";
+import {
+  listPersonInstalls,
+  personSkillsRoot,
+  type PersonInstallSummary,
+} from "@distilly/bindings";
 import type { Distilly } from "distilly";
 
 import { ambiguousCandidates, reusableSubject } from "./subject-errors.js";
@@ -887,13 +891,7 @@ const runPersonas = async (
     io.stdout.write(`${JSON.stringify({ host, installs: summaries }, undefined, 2)}\n`);
     return;
   }
-  const root = summaries.find((summary) => (summary.verified ? true : summary.host === host));
-  const skillsRoot =
-    root === undefined
-      ? "<no skills root found>"
-      : root.verified
-        ? dirname(root.install.path)
-        : dirname(root.path);
+  const skillsRoot = personSkillsRoot(host, hostHome(host, environment));
   io.stdout.write(`${describePersonInstalls(summaries, skillsRoot).join("\n")}\n`);
 };
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1376,7 +1376,7 @@ const help = `Distilly Developer Preview
 
 Usage:
   distilly setup --host codex
-  distilly setup --host claude-code|openclaw|hermes|dsh [--allow-unverified-host]
+  distilly setup --host claude-code|openclaw|hermes|dsh [--allow-unverified-host] [--repair]
   distilly doctor [--host <host>]
   distilly install <subject-id|display-name> --host <host>
   distilly import <legacy-directory> --host <host> [--name <display-name>|--subject <id>]
@@ -1426,12 +1426,21 @@ export const runPreviewCli = async (
   }
   if (command === "setup") {
     const allowUnverifiedHost = args.includes("--allow-unverified-host");
+    const repairDamagedHost = args.includes("--repair");
     const host = hostOption(
-      args.filter((argument) => argument !== "--allow-unverified-host"),
+      args.filter((argument) => argument !== "--allow-unverified-host" && argument !== "--repair"),
       true,
     );
     if (host === undefined) throw new Error("This command requires --host.");
-    const result = await setupPreviewHost(host, environment.lifecycle, { allowUnverifiedHost });
+    const result = await setupPreviewHost(host, environment.lifecycle, {
+      allowUnverifiedHost,
+      repairDamagedHost,
+    });
+    if (result.repairBackupPath !== undefined) {
+      io.stdout.write(
+        `The damaged Distilly plugin tree was preserved at ${result.repairBackupPath}.\n`,
+      );
+    }
     io.stdout.write(
       `Installed Distilly ${result.releaseVersion} for ${result.host}. Restart the host to discover it.\n`,
     );

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1150,6 +1150,22 @@ const runRollback = async (
     }
     const reason = flags.reason ?? `User rolled back to ${target_.id} from the distilly CLI.`;
     const rolled = await person.rollback({ versionId: target_.id, reason });
+    if (flags.asJson) {
+      io.stdout.write(
+        `${JSON.stringify(
+          {
+            subjectId: target.subject.id,
+            rolledBackTo: target_.id,
+            currentVersionId: rolled.id,
+            status: rolled.status,
+            reason,
+          },
+          undefined,
+          2,
+        )}\n`,
+      );
+      return;
+    }
     io.stdout.write(
       `Rolled ${target.subject.displayName} back to ${target_.id}.\nNew current version: ${rolled.id} (${statusLabel(rolled.status)}).\nReason recorded: ${reason}\n`,
     );

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -196,9 +196,10 @@ export const resolvePreviewCliEnvironment = async (): Promise<PreviewCliEnvironm
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
       throw error;
     });
+  const configuredDshHome = process.env["DSH_HOME"]?.trim();
   const dshHomeDirectory = resolve(
-    process.env["DSH_HOME"] !== undefined && process.env["DSH_HOME"].trim().length > 0
-      ? process.env["DSH_HOME"]
+    configuredDshHome !== undefined && configuredDshHome.length > 0
+      ? configuredDshHome
       : join(configuredHome, ".dsh"),
   );
   return {
@@ -398,7 +399,14 @@ const ingestFileSelection = async (
       const resolution = await application.distilly.resolve({
         selector: { kind: "query", query: request.displayName ?? "" },
       });
-      if (resolution.kind === "found") {
+      if (
+        resolution.kind === "found" &&
+        resolution.subject.displayName === (request.displayName ?? "") &&
+        // The engine's query also matches aliases, locators, and subjects in other spaces. Only
+        // an exact display-name match in the default people space is the same person; anything
+        // else must fall through to the create path, whose conflict handling refuses a merge.
+        resolution.subject.space.kind === "people"
+      ) {
         subjectId = resolution.subject.id;
         say(
           `${resolution.subject.displayName} (${resolution.subject.id}) already exists in ${resolution.subject.space.displayName}, so this material is added to it.\n`,
@@ -1121,7 +1129,7 @@ const runDiff = async (
 /**
  * Restores an earlier version as a new current version, keeping every version immutable.
  *
- * @param args - Subject, --host, --to, and optional --reason.
+ * @param args - Subject, --host, --to, optional --reason and --json.
  * @param environment - Resolved Preview CLI environment.
  * @param io - Command output streams.
  */
@@ -1154,7 +1162,7 @@ const runRollback = async (
  * Reads one path plus host, subject, and limit options for the legacy import command.
  *
  * @param args - Legacy directory plus options.
- * @returns Parsed options.
+ * @returns Parsed options, including whether the caller asked for JSON output.
  */
 const importOptions = (
   args: readonly string[],
@@ -1227,12 +1235,13 @@ const importOptions = (
  * @param args - Legacy directory plus host and subject options.
  * @param environment - Resolved Preview CLI environment.
  * @param io - Command output streams.
+ * @returns The process exit code: 1 when any person could not be imported.
  */
 const runImport = async (
   args: readonly string[],
   environment: PreviewCliEnvironment,
   io: PreviewCliIo,
-): Promise<void> => {
+): Promise<number> => {
   const options = importOptions(args);
   const people = await listLegacyPeople(options.directory);
   if (people.length === 0) {
@@ -1288,6 +1297,11 @@ const runImport = async (
       continue;
     }
     try {
+      if (personSubjectId !== undefined && personAliases.length > 0) {
+        note(
+          `  Note: ${personSubjectId} was chosen with --subject, so the legacy alias ${personAliases.map((alias) => `"${alias}"`).join(", ")} was not added to it.`,
+        );
+      }
       const outcome = await ingestFileSelection(
         {
           command: "import",
@@ -1320,8 +1334,8 @@ const runImport = async (
   }
   if (options.asJson) {
     io.stdout.write(`${JSON.stringify({ people: outcomes, failures, log }, undefined, 2)}\n`);
-    if (failures.length > 0) process.exitCode = 1;
-    return;
+    // The dispatcher owns the exit code; setting process.exitCode here would be overwritten.
+    return failures.length > 0 ? 1 : 0;
   }
   io.stdout.write(
     `\nImported ${String(outcomes.length)} of ${String(people.length)} legacy person(s).\n`,
@@ -1339,6 +1353,7 @@ const runImport = async (
       `${String(failures.length)} of ${String(people.length)} legacy person(s) could not be imported:\n${failures.join("\n")}`,
     );
   }
+  return 0;
 };
 
 const help = `Distilly Developer Preview
@@ -1352,7 +1367,7 @@ Usage:
                   [--sensitivity private|shareable] [--limit <n>] [--force] [--json]
   distilly versions <subject-id|display-name> --host <host> [--limit <n>] [--cursor <cursor>] [--json]
   distilly diff <subject-id|display-name> --host <host> --from <version> --to <version> [--json]
-  distilly rollback <subject-id|display-name> --host <host> --to <version> [--reason <text>]
+  distilly rollback <subject-id|display-name> --host <host> --to <version> [--reason <text>] [--json]
   distilly personas --host <host> [--json]
   distilly remove <subject-id|display-name> --host <host>
   distilly uninstall --host <host>
@@ -1438,8 +1453,7 @@ export const runPreviewCli = async (
     return 0;
   }
   if (command === "import") {
-    await runImport(args, environment, io);
-    return 0;
+    return await runImport(args, environment, io);
   }
   if (command === "versions") {
     await runVersions(args, environment, io);

--- a/packages/cli/src/versions.test.ts
+++ b/packages/cli/src/versions.test.ts
@@ -83,6 +83,7 @@ describe("version history rendering", () => {
     const historical = version("b", "historical", 1, "2026-09-10T22:40:04.437Z");
     const lines = describeVersions({ items: [suspended, historical] }, "Ada");
     expect(lines.join("\n")).toContain("No version is current right now");
+    expect(lines.join("\n")).toContain("awaiting review");
   });
 
   it("says a subject has no version yet instead of printing an empty table", () => {
@@ -126,6 +127,20 @@ describe("profile diff rendering", () => {
     expect(text).toContain("Changed facets: identity");
     expect(text).toContain("Claims: 1 -> 2 active");
     expect(text).toContain("+ [identity] Also asks what breaks second before shipping.");
+  });
+
+  it("names the status change when a changed claim keeps the same text", () => {
+    const before = { ...claim("Has lived in Berlin since 2019."), status: "active" } as Claim;
+    const after = {
+      ...claim("Has lived in Berlin since 2019."),
+      status: "contested",
+      strength: "contested",
+    } as Claim;
+    const text = describeProfileDiff(
+      diff({ added: [], removed: [], changed: [{ before, after }] }),
+    ).join("\n");
+    expect(text).toContain("status active -> contested");
+    expect(text).toContain("Has lived in Berlin since 2019.");
   });
 
   it("shows removed and changed claims with both texts", () => {

--- a/packages/cli/src/versions.ts
+++ b/packages/cli/src/versions.ts
@@ -51,7 +51,7 @@ export const describeVersions = (page: VersionPage, subjectName: string): readon
   if (current === undefined) {
     lines.push(
       "",
-      "No version is current right now: every listed version is historical or rejected, which happens while a candidate waits for review.",
+      "No version is current right now: the versions listed are historical, rejected, or a candidate awaiting review, which happens while a candidate waits for review.",
     );
   }
   if (page.nextCursor !== undefined) {
@@ -114,6 +114,14 @@ export const describeProfileDiff = (diff: ProfileDiff): readonly string[] => {
   if (diff.changed.length > 0) {
     lines.push("", "Changed claims:");
     for (const change of diff.changed) {
+      if (change.before.text === change.after.text) {
+        // The engine reports a status change (contested, superseded) as a changed claim with the
+        // same text, so the difference has to be named or the line reads as a no-op.
+        lines.push(
+          `  ~ [${change.after.facet}] status ${change.before.status} -> ${change.after.status}, strength ${change.before.strength} -> ${change.after.strength}: ${change.after.text}`,
+        );
+        continue;
+      }
       lines.push(`  ~ [${change.after.facet}] ${change.before.text}`);
       lines.push(`      -> ${change.after.text}`);
     }

--- a/packages/runtime/src/preview.test.ts
+++ b/packages/runtime/src/preview.test.ts
@@ -709,7 +709,9 @@ describe("unsplittable parsed text", () => {
     );
     expect(result.items).toHaveLength(1);
     expect(result.items[0]?.kind).toBe("unparsed");
-    expect(result.items[0]?.warnings.join(" ")).toContain("whitespace longer than one material");
+    expect(result.items[0]?.warnings.join(" ")).toContain(
+      "whitespace at least as long as one material",
+    );
   });
 });
 

--- a/packages/runtime/src/preview.ts
+++ b/packages/runtime/src/preview.ts
@@ -239,6 +239,19 @@ const createLocalFileLoader = () => {
                 ],
               };
             }
+            if (parts.length === 0) {
+              // Canonicalization removed everything (the text was only trailing whitespace), so
+              // there is no legal material here; keep the raw bytes and say why.
+              return {
+                pathLabel,
+                mediaType,
+                bytes,
+                source,
+                warnings: [
+                  "Parsed text is only whitespace after canonicalization; it was stored as an unparsed file.",
+                ],
+              };
+            }
             if (parts.length > WIRE_LIMITS.ingestMaterials) {
               // More parts than one ingest call can carry: refuse rather than drop any.
               return {

--- a/packages/runtime/src/split-parsed-text.test.ts
+++ b/packages/runtime/src/split-parsed-text.test.ts
@@ -22,6 +22,8 @@ const expectPartsOfCanonicalText = (text: string, parts: readonly string[]): voi
     expect(bytes(part)).toBeLessThanOrEqual(maximumBytes);
     // A part is stored unchanged only when it already equals its own canonical form.
     expect(canonicalize(part) === part).toBe(true);
+    // The engine refuses a material that is only whitespace, so no part may be.
+    expect(/[^\p{White_Space}]/u.test(part)).toBe(true);
   }
 };
 
@@ -196,7 +198,7 @@ describe("parsed text splitting", () => {
       "\n".repeat(maximumBytes + 1),
     ]) {
       expect(() => splitParsedText(text, maximumBytes)).toThrowError(
-        /whitespace longer than one material/u,
+        /whitespace at least as long as one material/u,
       );
     }
   });
@@ -214,6 +216,43 @@ describe("parsed text splitting", () => {
       const last = previous.codePointAt(previous.length - 1) ?? 0;
       expect(/^\p{M}$/u.test(String.fromCodePoint(last))).toBe(true);
     }
+  });
+
+  it("never leaves a part that is only whitespace", () => {
+    // A trailing newline, a blank line between two full parts, or a run that ends on a cut used
+    // to produce a whitespace-only part, which made the engine refuse the whole ingest call.
+    const full = "a".repeat(maximumBytes);
+    const trailing = splitParsedText(`${full}\n`, maximumBytes);
+    expect(trailing).toHaveLength(2);
+    expectPartsOfCanonicalText(`${full}\n`, trailing);
+
+    const blank = splitParsedText(
+      `${"a".repeat(524_288)}\n${"b".repeat(524_288)}\n\n${"c".repeat(10)}`,
+      maximumBytes,
+    );
+    expectPartsOfCanonicalText(
+      `${"a".repeat(524_288)}\n${"b".repeat(524_288)}\n\n${"c".repeat(10)}`,
+      blank,
+    );
+
+    const tiny = splitParsedText("aaaa\n", 4);
+    expect(tiny).toHaveLength(2);
+    for (const part of tiny) expect(/[^\p{White_Space}]/u.test(part)).toBe(true);
+    expect(tiny.join("")).toBe("aaaa\n");
+  });
+
+  it("refuses a whitespace run as long as one material instead of emitting a blank part", () => {
+    // A run of exactly the limit cannot be cut into parts that all carry content, and the
+    // engine refuses a whitespace-only material, so the file is refused with one warning.
+    expect(() => splitParsedText(`a${" ".repeat(maximumBytes)}b`, maximumBytes)).toThrowError(
+      /whitespace at least as long as one material/u,
+    );
+    expect(() => splitParsedText("a    b", 4)).toThrowError(/whitespace at least as long/u);
+    expect(() => splitParsedText("a\u00a0\u00a0", 4)).toThrowError(/whitespace at least as long/u);
+    // Text that canonicalization turns into nothing is not a refusal: the loader keeps the raw
+    // file with a warning, which is covered by the runtime test below.
+    expect(splitParsedText(" ".repeat(64), 32)).toEqual([]);
+    expect(() => splitParsedText("\n".repeat(32), 32)).toThrowError(/whitespace at least as long/u);
   });
 
   it("returns no parts for empty text", () => {

--- a/packages/runtime/src/split-parsed-text.ts
+++ b/packages/runtime/src/split-parsed-text.ts
@@ -74,7 +74,85 @@ export const splitParsedText = (text: string, maximumBytes: number): readonly st
     partBytes = 0;
   }
   if (partBytes > 0) parts.push(canonical.slice(partStart));
-  return parts;
+  return withoutWhitespaceOnlyParts(canonical, parts, maximumBytes);
+};
+
+/**
+ * Repairs parts that would be refused as whitespace-only material.
+ *
+ * A trailing newline, a blank line between two full parts, or a run that ends exactly on a cut
+ * can leave a part made only of whitespace, and the engine refuses that material outright. Each
+ * such part takes the next non-whitespace code point when the byte ceiling allows it, the last
+ * part may take bytes back from the part before it, and text where neither is possible is
+ * refused as one file.
+ *
+ * @param text - Canonical text the parts were cut from.
+ * @param parts - Parts produced by the cut.
+ * @param maximumBytes - Largest UTF-8 byte length one part may have.
+ * @returns Parts that each contain at least one non-whitespace code point.
+ */
+const withoutWhitespaceOnlyParts = (
+  text: string,
+  parts: readonly string[],
+  maximumBytes: number,
+): readonly string[] => {
+  const ranges: { start: number; end: number }[] = [];
+  let offset = 0;
+  for (const part of parts) {
+    ranges.push({ start: offset, end: offset + part.length });
+    offset += part.length;
+  }
+  for (let index = 0; index < ranges.length; index += 1) {
+    const range = ranges[index];
+    if (range === undefined) continue;
+    if (!isWhitespaceOnly(text, range.start, range.end)) continue;
+    // Take the next part's code points until this part holds something that is not whitespace.
+    while (index + 1 < ranges.length && isWhitespaceOnly(text, range.start, range.end)) {
+      const next = ranges[index + 1];
+      if (next === undefined) break;
+      const codePoint = text.codePointAt(next.start) ?? 0;
+      const grown = range.end + (codePoint > 0xffff ? 2 : 1);
+      if (utf8BytesIn(text, range.start, grown) > maximumBytes) break;
+      range.end = grown;
+      next.start = grown;
+      if (next.start >= next.end) ranges.splice(index + 1, 1);
+    }
+    // The final part can instead take bytes back from the part before it.
+    while (
+      index === ranges.length - 1 &&
+      isWhitespaceOnly(text, range.start, range.end) &&
+      index > 0
+    ) {
+      const previous = ranges[index - 1];
+      if (previous === undefined || previous.end - previous.start <= 1) break;
+      const codePointStart = previousCodePointStart(text, previous.end, previous.start);
+      if (codePointStart <= previous.start) break;
+      range.start = codePointStart;
+      previous.end = codePointStart;
+    }
+    if (isWhitespaceOnly(text, range.start, range.end)) {
+      throw unusableWhitespace(maximumBytes, utf8BytesIn(text, range.start, range.end));
+    }
+  }
+  return ranges.map((range) => text.slice(range.start, range.end));
+};
+
+/**
+ * Reports whether a slice of the canonical text holds no non-whitespace code point.
+ *
+ * @param text - Canonical text.
+ * @param start - First UTF-16 index of the slice.
+ * @param end - Exclusive end of the slice.
+ * @returns True when every code point in the slice is whitespace.
+ */
+const isWhitespaceOnly = (text: string, start: number, end: number): boolean => {
+  let index = start;
+  while (index < end) {
+    const codePoint = text.codePointAt(index) ?? 0;
+    if (!isEngineWhitespace(codePoint)) return false;
+    index += codePoint > 0xffff ? 2 : 1;
+  }
+  return true;
 };
 
 /** Matches one combining mark, which must not be separated from the base it modifies. */
@@ -118,29 +196,45 @@ const isHorizontalWhitespace = (code: number): boolean => code === 0x20 || code 
  * @param maximumBytes - Largest UTF-8 byte length one part may have.
  */
 const assertNoOversizedWhitespaceRun = (text: string, maximumBytes: number): void => {
+  if (text.length === 0) return;
   let runBytes = 0;
   let index = 0;
+  let hasContent = false;
   while (index < text.length) {
     const codePoint = text.codePointAt(index) ?? 0;
     if (isEngineWhitespace(codePoint)) {
       runBytes += utf8Width(codePoint);
-      if (runBytes > maximumBytes) {
-        throw new DistillyError({
-          code: "context_too_large",
-          message:
-            "Parsed text contains a run of whitespace longer than one material, which cannot be split into legal parts.",
-          retryable: false,
-          fieldPath: "material.content",
-          remediation: "Narrow the selected file and try again.",
-          details: { maximumBytes, whitespaceRunBytes: runBytes },
-        });
+      // A run of exactly one material can only be cut into whitespace-only parts, which the
+      // engine refuses, so it is refused here as one file instead of failing the whole call.
+      if (runBytes >= maximumBytes) {
+        throw unusableWhitespace(maximumBytes, runBytes);
       }
     } else {
+      hasContent = true;
       runBytes = 0;
     }
     index += codePoint > 0xffff ? 2 : 1;
   }
+  if (!hasContent) throw unusableWhitespace(maximumBytes, runBytes);
 };
+
+/**
+ * Builds the typed refusal for text that cannot become legal parts.
+ *
+ * @param maximumBytes - Largest UTF-8 byte length one part may have.
+ * @param whitespaceRunBytes - Bytes in the run that made the text unusable.
+ * @returns The error the loader turns into a per-file warning.
+ */
+const unusableWhitespace = (maximumBytes: number, whitespaceRunBytes: number): DistillyError =>
+  new DistillyError({
+    code: "context_too_large",
+    message:
+      "Parsed text contains a run of whitespace at least as long as one material, which cannot be split into legal parts.",
+    retryable: false,
+    fieldPath: "material.content",
+    remediation: "Narrow the selected file and try again.",
+    details: { maximumBytes, whitespaceRunBytes },
+  });
 
 /**
  * Moves a line-boundary cut forward over combining marks that begin the next line.


### PR DESCRIPTION
## What
fix: audit findings (persona registration, parsers, repair path, JSON output)

## Commits
- fix(bindings): register a Claude Code person Skill with the host
- fix(adapters,cli,bindings): close the round-17 and round-14 findings
- fix(cli): make rollback --json emit JSON
- feat(cli,bindings): repair a damaged host integration on request
- fix(cli): name the real skills root when no person Skill is installed

## Stack
Stacked on `pr/11-docs-and-release-check`; the whole series ends at `distilly-work` (`0bd924e`).

## Verification
Every feature carries an author report and an independent audit in the delivery evidence folder (`host-verification/`), including screenshots and the audit verdict that drove the fixes. Gates on the top of the stack: format, lint, docs, release check, and 1163 tests.

## Real hosts
Codex, Claude Code 2.1.268, OpenClaw 2026.9.2, Hermes v0.19.0, and DSH 0.1.5-rc.1 were each exercised end to end (install, host-visible confirmation, exactly five MCP tools, person Skill install/remove, uninstall). Capacity fixtures are recorded for Codex 0.146.0, OpenClaw 2026.3.24, and Hermes v0.9.0; newer host versions run on the labelled conservative floor.

## Evidence
Author reports and screenshots (delivery evidence folder `host-verification/`):
- f21-round14-17-fixes-REPORT.md, f21-round17-fixes.png, f22-version-fixes.png
- f24-damaged-install-repair-REPORT.md, f24-damaged-install-repair.png
- f25-host-reverification-REPORT.md, f25-hermes-at-head.png

Independent audit reports:
- round17-parsers-and-versions-VERIFY.md, round18-claude-code-openclaw-VERIFY.md, round14-dsh-and-splitter-VERIFY.md; independent re-verification of this PR is in progress (two earlier attempts died from resource exhaustion)