### PR TITLE
ci: green type check on a fresh checkout, and a working pip cache path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+          # The repository keeps its Python dependencies in requirements-dev.txt; without an
+          # explicit path the cache step fails on a repository with no requirements.txt.
+          cache-dependency-path: requirements-dev.txt
       - name: Install lint dependencies
         run: pip install -r requirements-dev.txt
       - name: Run Ruff

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint .",
     "gates:fast": "pnpm run format:check && pnpm run lint",
-    "typecheck": "pnpm -r exec tsc --noEmit -p tsconfig.json && pnpm -r --if-present run typecheck && tsc --noEmit -p tsconfig.tools.json",
+    "typecheck": "tsc -b && pnpm -r exec tsc --noEmit -p tsconfig.json && pnpm -r --if-present run typecheck && tsc --noEmit -p tsconfig.tools.json",
     "test": "vitest run && pnpm run test:panel-browser && pnpm run test:boundaries && pnpm run test:build-artifacts && pnpm run test:plugins",
     "test:coverage": "vitest run --coverage",
     "test:panel-http": "vitest run packages/panel/src/server-http.test.ts packages/panel/src/web-client.test.ts packages/panel/src/server-launcher.test.ts packages/panel/src/web-boundaries.test.ts",


### PR DESCRIPTION
## What
Make the repository CI usable again:

- `pnpm run typecheck` now builds the referenced projects first, so it works on a fresh checkout instead of failing every project reference with `TS6305`.
- The Ruff job points its pip cache at `requirements-dev.txt`; `actions/setup-python` was failing before Ruff ran at all, because the repository has no `requirements.txt`.

Both failures pre-date this branch: every recent CI run on `distilly-plugin` is red for the same reasons.

## Verification
Moved every package's built output aside to simulate a fresh checkout, then ran `pnpm run typecheck`: exit 0, zero errors. Format and lint gates pass.

## Stack
Stacked on `pr/12-audit-fixes-and-repair`; the series ends at `distilly-work` (`9ab229e`).
